### PR TITLE
v1.0.0 of the API Clients

### DIFF
--- a/.changeset/bright-pumpkins-crash.md
+++ b/.changeset/bright-pumpkins-crash.md
@@ -1,5 +1,5 @@
 ---
-"@ts-ghost/core-api": minor
+"@ts-ghost/core-api": major
 ---
 
 Breaking Changes, QueryBuilder API now only have input params, output is handled on the fetcher

--- a/.changeset/bright-pumpkins-crash.md
+++ b/.changeset/bright-pumpkins-crash.md
@@ -1,0 +1,5 @@
+---
+"@ts-ghost/core-api": minor
+---
+
+Breaking Changes, QueryBuilder API now only have input params, output is handled on the fetcher

--- a/.changeset/bright-pumpkins-crash.md
+++ b/.changeset/bright-pumpkins-crash.md
@@ -2,4 +2,66 @@
 "@ts-ghost/core-api": major
 ---
 
-Breaking Changes, QueryBuilder API now only have input params, output is handled on the fetcher
+## Breaking Changes
+
+QueryBuilder API now only have input params, output is handled on the fetcher via the `fields`, `formats` and `include` methods.
+
+### Before 
+
+Given this queries in the old API
+```ts
+const qb = new QueryBuilder(
+  { schema: simplifiedSchema, output: simplifiedSchema, include: simplifiedIncludeSchema },
+  api
+);
+let query = qb.browse({
+  input: {
+    limit: 5,
+    order: "title DESC"
+  },
+  output: {
+    include: {
+      count: true,
+    },
+  },
+});
+
+let readQuery = qb.read({
+  input: {
+    slug: "test-post"
+  },
+  output: {
+    fields: {
+      slug: true,
+      count: true,
+    },
+  },
+});
+```
+
+### After
+
+Rewritten in the new API version:
+
+```ts
+const qb = new QueryBuilder(
+  { schema: simplifiedSchema, output: simplifiedSchema, include: simplifiedIncludeSchema },
+  api
+);
+let browseQuery = qb.browse({
+  limit: 5,
+  order: "title DESC"
+}).include({count: true});
+
+let readQuery = qb.read({
+  slug: "test-post",
+}).fields({
+  slug: true,
+  count: true,
+});
+```
+
+## Other changes
+
+- Updated documentation
+- Code cleanup

--- a/.changeset/fast-penguins-flash.md
+++ b/.changeset/fast-penguins-flash.md
@@ -3,4 +3,66 @@
 "@ts-ghost/admin-api": major
 ---
 
-Migrate to the new QueryBuilder and Fetcher API
+## Breaking Changes
+
+`@ts-ghost/core-api` QueryBuilder and Fetcher were updated so this package also sees its API updated. Now the resource only have input params, output is handled on the fetcher via the `fields`, `formats` and `include` methods.
+
+### Before 
+
+Given this queries in the old API
+```ts
+const posts = await api.posts.browse({
+  input: {
+    limit: 5,
+    order: "title DESC"
+  },
+  output: {
+    include: {
+      authors: true,
+    },
+  },
+}).fetch();
+
+const onePost = await api.posts.read({
+  input: {
+    slug: "test-post"
+  },
+  output: {
+    fields: {
+      slug: true,
+      html: true,
+    },
+  },
+}).fetch();
+```
+
+### After
+
+Rewritten in the new API version:
+
+```ts
+const posts = await api.posts
+  .browse({
+    limit: 5,
+    order: "title DESC"
+  })
+  .include({
+    authors: true,
+  })
+  .fetch();
+
+const onePost = await api.posts
+  .read({
+    slug: "test-post"
+  })
+  .fields({
+    slug: true,
+    html: true,
+  })
+  .fetch();
+```
+
+## Other changes
+
+- Updated documentation
+- Code cleanup

--- a/.changeset/fast-penguins-flash.md
+++ b/.changeset/fast-penguins-flash.md
@@ -1,0 +1,6 @@
+---
+"@ts-ghost/content-api": minor
+"@ts-ghost/admin-api": minor
+---
+
+Migrate to the new QueryBuilder and Fetcher API

--- a/.changeset/fast-penguins-flash.md
+++ b/.changeset/fast-penguins-flash.md
@@ -1,6 +1,6 @@
 ---
-"@ts-ghost/content-api": minor
-"@ts-ghost/admin-api": minor
+"@ts-ghost/content-api": major
+"@ts-ghost/admin-api": major
 ---
 
 Migrate to the new QueryBuilder and Fetcher API

--- a/.changeset/rude-rules-reflect.md
+++ b/.changeset/rude-rules-reflect.md
@@ -1,0 +1,5 @@
+---
+"@ts-ghost/ghost-blog-buster": minor
+---
+
+Migrate to the newer versions of content and admin API

--- a/.changeset/rude-rules-reflect.md
+++ b/.changeset/rude-rules-reflect.md
@@ -2,4 +2,4 @@
 "@ts-ghost/ghost-blog-buster": minor
 ---
 
-Migrate to the newer versions of content and admin API
+Migrate to the newer versions of content and admin API, no user-facing changes.

--- a/apps/ghost-blog-buster/src/commands/export-admin.ts
+++ b/apps/ghost-blog-buster/src/commands/export-admin.ts
@@ -57,10 +57,8 @@ export const handler = async function (argv: ArgumentsCamelCase<{ host?: string;
       while (currentPage <= pages) {
         const res = await api.posts
           .browse({
-            input: {
-              page: currentPage,
-              filter: "html:-null",
-            },
+            page: currentPage,
+            filter: "html:-null",
           })
           .formats({ html: true })
           .fetch();
@@ -93,10 +91,8 @@ export const handler = async function (argv: ArgumentsCamelCase<{ host?: string;
       while (currentPage <= pages) {
         const res = await api.pages
           .browse({
-            input: {
-              page: currentPage,
-              filter: "html:-null",
-            },
+            page: currentPage,
+            filter: "html:-null",
           })
           .formats({ html: true })
           .fetch();

--- a/apps/ghost-blog-buster/src/commands/export-content.ts
+++ b/apps/ghost-blog-buster/src/commands/export-content.ts
@@ -56,15 +56,11 @@ export const handler = async function (argv: ArgumentsCamelCase<{ host?: string;
       while (currentPage <= pages) {
         const res = await api.posts
           .browse({
-            input: {
-              page: currentPage,
-            },
-            output: {
-              include: {
-                authors: true,
-                tags: true,
-              },
-            },
+            page: currentPage,
+          })
+          .include({
+            authors: true,
+            tags: true,
           })
           .fetch();
         if (res.status === "error") {
@@ -96,15 +92,11 @@ export const handler = async function (argv: ArgumentsCamelCase<{ host?: string;
       while (currentPage <= pages) {
         const res = await api.pages
           .browse({
-            input: {
-              page: currentPage,
-            },
-            output: {
-              include: {
-                authors: true,
-                tags: true,
-              },
-            },
+            page: currentPage,
+          })
+          .include({
+            authors: true,
+            tags: true,
           })
           .fetch();
         if (res.status === "error") {
@@ -130,12 +122,9 @@ export const handler = async function (argv: ArgumentsCamelCase<{ host?: string;
     }
     case "authors": {
       const res = await api.authors
-        .browse({
-          output: {
-            include: {
-              "count.posts": true,
-            },
-          },
+        .browse()
+        .include({
+          "count.posts": true,
         })
         .fetch();
       if (res.status === "error") {
@@ -160,12 +149,9 @@ export const handler = async function (argv: ArgumentsCamelCase<{ host?: string;
     }
     case "tags": {
       const res = await api.tags
-        .browse({
-          output: {
-            include: {
-              "count.posts": true,
-            },
-          },
+        .browse()
+        .include({
+          "count.posts": true,
         })
         .fetch();
       if (res.status === "error") {
@@ -190,14 +176,11 @@ export const handler = async function (argv: ArgumentsCamelCase<{ host?: string;
     }
     case "tiers": {
       const res = await api.tiers
-        .browse({
-          output: {
-            include: {
-              benefits: true,
-              monthly_price: true,
-              yearly_price: true,
-            },
-          },
+        .browse()
+        .include({
+          benefits: true,
+          monthly_price: true,
+          yearly_price: true,
         })
         .fetch();
       if (res.status === "error") {

--- a/apps/ghost-blog-buster/src/commands/interactive-admin-api/helpers.ts
+++ b/apps/ghost-blog-buster/src/commands/interactive-admin-api/helpers.ts
@@ -4,10 +4,8 @@ export const fetchAllBlogPosts = async (ghost: TSGhostAdminAPI) => {
   const posts: (Post & { html: string | null })[] = [];
   let cursor = await ghost.posts
     .browse({
-      input: {
-        filter: "html:-null",
-        order: "published_at DESC,updated_at DESC",
-      },
+      filter: "html:-null",
+      order: "published_at DESC,updated_at DESC",
     })
     .formats({ html: true })
     .paginate();

--- a/apps/ghost-blog-buster/src/commands/interactive-admin-api/posts-export-all.ts
+++ b/apps/ghost-blog-buster/src/commands/interactive-admin-api/posts-export-all.ts
@@ -40,10 +40,8 @@ export async function postsExportAll(ghost: TSGhostAdminAPI, siteName: string) {
 
     const res = await ghost.posts
       .browse({
-        input: {
-          filter: "html:-null",
-          page: currentPage,
-        },
+        filter: "html:-null",
+        page: currentPage,
       })
       .formats({ html: true })
       .fetch();

--- a/apps/ghost-blog-buster/src/commands/interactive-content-api/authors-export-all.ts
+++ b/apps/ghost-blog-buster/src/commands/interactive-content-api/authors-export-all.ts
@@ -47,12 +47,9 @@ export const authorsExportAll = async (ghost: TSGhostContentAPI, siteName: strin
 
   s.start(`Fetching Authors...`);
   const authors = await ghost.authors
-    .browse({
-      output: {
-        include: {
-          "count.posts": true,
-        },
-      },
+    .browse()
+    .include({
+      "count.posts": true,
     })
     .fetch();
   if (authors.status === "error") {

--- a/apps/ghost-blog-buster/src/commands/interactive-content-api/helpers.ts
+++ b/apps/ghost-blog-buster/src/commands/interactive-content-api/helpers.ts
@@ -3,13 +3,10 @@ import type { Post, TSGhostContentAPI } from "@ts-ghost/content-api";
 export const fetchAllBlogPosts = async (ghost: TSGhostContentAPI) => {
   const posts: Post[] = [];
   let cursor = await ghost.posts
-    .browse({
-      output: {
-        include: {
-          authors: true,
-          tags: true,
-        },
-      },
+    .browse()
+    .include({
+      authors: true,
+      tags: true,
     })
     .paginate();
   if (cursor.current.status === "success") posts.push(...cursor.current.data);

--- a/apps/ghost-blog-buster/src/commands/interactive-content-api/posts-export-all.ts
+++ b/apps/ghost-blog-buster/src/commands/interactive-content-api/posts-export-all.ts
@@ -40,15 +40,11 @@ export async function postsExportAll(ghost: TSGhostContentAPI, siteName: string)
 
     const res = await ghost.posts
       .browse({
-        input: {
-          page: currentPage,
-        },
-        output: {
-          include: {
-            authors: true,
-            tags: true,
-          },
-        },
+        page: currentPage,
+      })
+      .include({
+        authors: true,
+        tags: true,
       })
       .fetch();
     if (res.status === "error" || res.data.length === 0) {

--- a/apps/ghost-blog-buster/src/index.ts
+++ b/apps/ghost-blog-buster/src/index.ts
@@ -5,10 +5,8 @@ const ghost = new TSGhostAdminAPI("https://ghost.org/ghost/api/admin", "1234", "
 
 const posts = await ghost.posts
   .browse({
-    input: {
-      filter: "html:-null",
-      limit: 5,
-    },
+    filter: "html:-null",
+    limit: 5,
   })
   .formats({ html: true })
   .fields({ slug: true, html: true })

--- a/packages/ts-ghost-admin-api/README.md
+++ b/packages/ts-ghost-admin-api/README.md
@@ -77,9 +77,7 @@ let key = "22444f78447824223cefc48062"; // Admin API KEY
 const api = new TSGhostAdminAPI(url, key, "v5.0");
 
 const res = await api.posts.read({
-  input: {
-    slug: "welcome-to-ghost",
-  }
+  slug: "welcome-to-ghost",
 }).fetch();
 if (res.status === "success") {
   const post = res.data;
@@ -97,54 +95,43 @@ new instance of a QueryBuilder containing two methods `read` and `browse`.
 This instance is already built with the associated Schema for that resource so any operation 
 you will do from that point will be typed against the asociated schema.
 
-`browse` and `read` methods accept a config object with 2 properties: `input` and an `output`. These params mimic the way Ghost API is built but with the power of Zod and TypeScript they are type-safe here.
+`browse` and `read` methods accept an options object. These params mimic the way Ghost API is built but with the power of Zod and TypeScript they are type-safe here.
 
 ```typescript
-let query = api.posts.browse({
-  input: {
+let query = api.posts
+  .browse({
     limit: 5,
     order: "title DESC"
     //      ^? the text here will throw a TypeScript lint error if you use unknown field.
-  },
-  output: {
-    include: {
-      authors: true,
-      tags: true,
-    },
-  },
-});
+  })
+  .include({
+    authors: true,
+    tags: true,
+  });
 ```
 
-- `input` will accept browse parameters like `page`, `limit`, `order`, `filter`. And read parameters are `id` or `slug`.
-- `output` is the same for both methods and let you specify `fields` to output (to not have the full object) and some Schema specific `include`. For example getting the posts including their Authors.
+- `browse` will accept browse parameters like `page`, `limit`, `order`, `filter`. 
+- `read` parameters are `id` or `slug`.
 
-*Ghost Admin API doesn't work well when you mix `fields` and `include` output, so in most case you shouldn't*
+## Options 
 
-## `input`
+### `.browse` options
 
-### `.browse` inputs
+Params are totally optionals on the `browse` method but they let you filter and order your search.
 
-Input are totally optionals on the `browse` method but they let you filter and order your search.
-
-This is an example containing all the available keys in the `input` object
+This is an example containing all the available keys in the params object
 
 ```typescript
 let query = api.posts.browse({
-  input: {
-    page: 1,
-    limit: 5,
-    filter: "name:bar+slug:-test",
-    //      ^? the text here will throw a TypeScript lint error if you use unknown fields.
-    order: "title DESC"
-    //      ^? the text here will throw a TypeScript lint error if you use unknown fields.
-  }
+  page: 1,
+  limit: 5,
+  filter: "name:bar+slug:-test",
+  //      ^? the text here will throw a TypeScript lint error if you use unknown fields.
+  order: "title DESC"
+  //      ^? the text here will throw a TypeScript lint error if you use unknown fields.
 });
 ```
 These browse params are then parsed through a `Zod` Schema that will validate all the fields.
-
-#### (Deprecated) Type-hint with `as const`
-~~You should use `as const` for your input if you are playing with `filter` and `order` so TypeScript can analyse the content of the string statically and TypeCheck it.~~
-This is not needed anymore since TypeScript release 5.0 the generics use const inference.
 
 - `page:number` The current page requested
 - `limit:number` Between 0 and 15 (limitation of the Ghost API)
@@ -153,44 +140,35 @@ This is not needed anymore since TypeScript release 5.0 the generics use const i
 
 For the `order` and `filter` if you use fields that are not present on the schema (for example `name` on a `Post`) then the QueryBuilder will throw an Error with message containing the unknown field.
 
-### `.read` inputs
+### `.read` options
 Read is meant to be used to fetch 1 object only by `id` or `slug`. 
 
 ```typescript
 let query = api.posts.read({
-  input: {
-    id: "edHks74hdKqhs34izzahd45"
-  }
+  id: "edHks74hdKqhs34izzahd45"
 }); 
 
 // or 
 
 let query = api.posts.read({
-  input: {
-    slug: "typescript-is-awesome-in-2025"
-  }
+  slug: "typescript-is-awesome-in-2025"
 }); 
 ```
 You can submit **both** `id` and `slug`, but the fetcher will then chose the `id` in priority if present to make the final URL query to the Ghost API.
 
-## `output`
-Output is the same for both `browse` and `read` methods and gives you 2 keys to play with
+## Modifying the `output` after read or browse.
+Both `browse` and `read` methods give you a Fetcher with methods that alter the output of the results. The output type will be modified to match the fields, inclusion or format you selected. These methods are **chainable**.
 
-### `fields` 
-The `fields` key lets you change the output of the result to have only your selected fields, it works by giving the key and the value `true` to the field you want to keep. Under the hood it will use the `zod.pick` method to pick only the fields you want.
+### `.fields()` 
+The `fields` method lets you change the output of the result to have only your selected fields, it works by giving an object with the field name and the value `true`. Under the hood it will use the `zod.pick` method to pick only the fields you want.
 
 ```typescript
 let result = await api.posts.read({
-  input: {
-    slug: "typescript-is-cool"
-  },
-  output: {
-    fields: {
-      id: true,
-      slug: true,
-      title: true
-    }
-  }
+  slug: "typescript-is-cool"
+}).fields({
+  id: true,
+  slug: true,
+  title: true
 }).fetch();
 
 if (result.status === 'success') {
@@ -200,6 +178,40 @@ if (result.status === 'success') {
 ```
 The **output schema** will be modified to only have the fields you selected and TypeScript will pick up on that to warn you if you access non-existing fields.
 
+### `.include()`
+The `include` method lets you include some additionnal data that the Ghost API doesn't give you by default. The `include` params is specific to each resource and is defined in the "include" `Schema` of the resource. You will have to let TypeScript guide you to know what you can include.
+
+```typescript
+let result = await api.authors.read({
+  slug: "phildl"
+}).include({ "count.posts": true }).fetch();
+```
+
+Available include keys by resource:
+- Posts & Pages: `authors`, `tags`
+- Authors: `count.posts`
+- Tags: `count.posts`
+- Tiers: `monthly_price`, `yearly_price`, `benefits`
+
+The output type will be modified to make the fields you include **non-optionals**.
+
+### `.formats()`
+The `formats` method lets you add alternative content formats on the output of `Post` or `Page` resource to get the content in `plaintext` or `html`. Available options are `plaintext | html | mobiledoc`.
+
+```typescript
+let result = await api.posts
+  .read({
+    slug: "this-is-a-post-slug"
+  })
+  .formats({ 
+    plaintext: true, 
+    html: true,
+    mobiledoc: true
+  })
+  .fetch();
+```
+
+The output type will be modified to make the formatted fields you include **non-optionals**.
 
 ## Fetching 
 After building your query you can fetch it with the `fetch` method. This method will return a `Promise` that will resolve to a result object that was parsed by the `Zod` Schema of the resource. 
@@ -207,7 +219,7 @@ After building your query you can fetch it with the `fetch` method. This method 
 All the results are discriminated unions representing a successful query and an error query. To discriminate the results you can use the `status` key of the result object which is `success` or `error`.
 
 ```typescript
-let result = await api.posts.read({input: {slug: "typescript-is-cool"}}).fetch();
+let result = await api.posts.read({ slug: "typescript-is-cool" }).fetch();
 if (result.status === 'success') {
   const post = result.data;
   //     ^? type {"id": string; "slug":string; "title": string}
@@ -335,11 +347,8 @@ const outputFields = fieldsKeys.reduce((acc, k) => {
   return acc;
 }, {} as { [k in keyof Post]?: true | undefined });
 const result = await api.posts
-  .browse({
-    output: {
-      fields: outputFields,
-    },
-  })
+  .browse()
+  .fields(outputFields)
   .fetch();
 ```
 
@@ -355,11 +364,7 @@ const outputFields = {
   title: true,
 } satisfies { [k in keyof Post]?: true | undefined };
 
-let test = api.posts.browse({
-  output: {
-    fields: outputFields,
-  },
-});
+let test = api.posts.browse().fields(outputFields);
 ```
 In that case you will **keep type-safety** and the output will be of type `Post` with only the fields you selected.
 
@@ -376,17 +381,15 @@ const order = "foobar DESC";
 const input = { order } as BrowseParams<{ order: string }, Post>;
 const result = await api.posts
   .browse({
-    input: {
-      order,
-    },
+    order
   })
   .fetch();
 ```
 
 ## Roadmap
 
-- [x] Write more docs
-- [ ] Better handling of weird Ghost "include" params in API call
+- [ ] Handle POST, PUT, DELETE requests
+- [ ] Handle Image and Theme uploads
 
 ## Contributing
 

--- a/packages/ts-ghost-admin-api/package.json
+++ b/packages/ts-ghost-admin-api/package.json
@@ -42,7 +42,8 @@
     "vite": "^4.2.1",
     "vite-tsconfig-paths": "^4.0.7",
     "vitest": "^0.29.7",
-    "zod": "^3.20.6"
+    "zod": "^3.20.6",
+    "cross-fetch": "^3.1.5"
   },
   "dependencies": {
     "@ts-ghost/core-api": "^0.3.2",

--- a/packages/ts-ghost-admin-api/src/admin-api.ts
+++ b/packages/ts-ghost-admin-api/src/admin-api.ts
@@ -44,7 +44,6 @@ export class TSGhostAdminAPI {
         schema: adminPostsSchema,
         output: adminPostsSchema,
         include: postsIncludeSchema,
-        formats: z.array(z.enum(["html", "mobiledoc", "plaintext"])),
       },
       api
     );
@@ -73,7 +72,6 @@ export class TSGhostAdminAPI {
         schema: adminPagesSchema,
         output: adminPagesSchema,
         include: pagesIncludeSchema,
-        formats: z.array(z.enum(["html", "mobiledoc", "plaintext"])),
       },
       api
     );

--- a/packages/ts-ghost-admin-api/src/playground.example.ts
+++ b/packages/ts-ghost-admin-api/src/playground.example.ts
@@ -23,9 +23,7 @@ const api = new TSGhostAdminAPI(
 const users = async () => {
   const users = await api.users
     .read({
-      input: {
-        id: "1",
-      },
+      id: "1",
     })
     .fetch();
   console.log("users", users);

--- a/packages/ts-ghost-admin-api/src/schemas/members.integration.test.ts
+++ b/packages/ts-ghost-admin-api/src/schemas/members.integration.test.ts
@@ -63,7 +63,7 @@ describe("members integration tests browse", () => {
     expect(api.members).toBeDefined();
     const result = await api.members
       .browse({
-        input: { limit: 1 },
+        limit: 1,
       })
       .fetch();
 
@@ -97,7 +97,7 @@ describe("members integration tests browse", () => {
     expect(api.members).toBeDefined();
     const result = await api.members
       .read({
-        input: { id: "64113de3e54f8b0001789b4e" },
+        id: "64113de3e54f8b0001789b4e",
       })
       .fetch();
     assert(result.status === "success");

--- a/packages/ts-ghost-admin-api/src/schemas/members.integration.test.ts
+++ b/packages/ts-ghost-admin-api/src/schemas/members.integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, beforeEach, assert } from "vitest";
+import { describe, test, beforeEach, assert, expect } from "vitest";
 import { TSGhostAdminAPI } from "../admin-api";
 
 const stubMember = {

--- a/packages/ts-ghost-admin-api/src/schemas/newsletters.integration.test.ts
+++ b/packages/ts-ghost-admin-api/src/schemas/newsletters.integration.test.ts
@@ -50,7 +50,7 @@ describe("newsletters integration tests browse", () => {
     expect(api.newsletters).toBeDefined();
     const result = await api.newsletters
       .browse({
-        input: { limit: 1 },
+        limit: 1,
       })
       .fetch();
 
@@ -86,7 +86,7 @@ describe("newsletters integration tests browse", () => {
     expect(api.newsletters).toBeDefined();
     const result = await api.newsletters
       .read({
-        input: { id: "63887bd07f2cf30001fec7a4" },
+        id: "63887bd07f2cf30001fec7a4",
       })
       .fetch();
     assert(result.status === "success");

--- a/packages/ts-ghost-admin-api/src/schemas/newsletters.integration.test.ts
+++ b/packages/ts-ghost-admin-api/src/schemas/newsletters.integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, beforeEach, assert } from "vitest";
+import { describe, test, beforeEach, assert, expect } from "vitest";
 import { TSGhostAdminAPI } from "../admin-api";
 
 const stubResult = {

--- a/packages/ts-ghost-admin-api/src/schemas/pages.integration.test.ts
+++ b/packages/ts-ghost-admin-api/src/schemas/pages.integration.test.ts
@@ -199,7 +199,7 @@ describe("pages integration tests browse", () => {
     expect(api.pages).toBeDefined();
     const result = await api.pages
       .browse({
-        input: { limit: 1 },
+        limit: 1,
       })
       .formats({ html: true, plaintext: true })
       .fetch();
@@ -311,7 +311,7 @@ describe("pages integration tests browse", () => {
     expect(api.pages).toBeDefined();
     const result = await api.pages
       .read({
-        input: { slug: "about" },
+        slug: "about",
       })
       .formats({ html: true, plaintext: true })
       .fetch();
@@ -428,7 +428,7 @@ describe("pages integration tests browse", () => {
     expect(api.pages).toBeDefined();
     const result = await api.pages
       .browse({
-        input: { limit: 1 },
+        limit: 1,
       })
       .formats({ html: true, plaintext: true })
       .fetch();
@@ -436,7 +436,7 @@ describe("pages integration tests browse", () => {
     expect(result.errors[0].message).toBe("Unknown Admin API Key");
     const resultR = await api.pages
       .read({
-        input: { slug: "about" },
+        slug: "about",
       })
       .formats({ html: true, plaintext: true })
       .fetch();
@@ -453,7 +453,7 @@ describe("pages integration tests browse", () => {
     expect(api.pages).toBeDefined();
     const result = await api.pages
       .browse({
-        input: { limit: 1 },
+        limit: 1,
       })
       .formats({ html: true, plaintext: true })
       .fetch();
@@ -461,7 +461,7 @@ describe("pages integration tests browse", () => {
     expect(result.errors[0].message).toContain("FetchError");
     const resultR = await api.pages
       .read({
-        input: { slug: "about" },
+        slug: "about",
       })
       .formats({ html: true, plaintext: true })
       .fetch();

--- a/packages/ts-ghost-admin-api/src/schemas/pages.integration.test.ts
+++ b/packages/ts-ghost-admin-api/src/schemas/pages.integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, beforeEach, assert } from "vitest";
+import { describe, test, beforeEach, assert, expect } from "vitest";
 import { TSGhostAdminAPI } from "../admin-api";
 
 const stubPage = {

--- a/packages/ts-ghost-admin-api/src/schemas/posts.integration.test.ts
+++ b/packages/ts-ghost-admin-api/src/schemas/posts.integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, beforeEach, assert } from "vitest";
+import { describe, test, beforeEach, assert, expect } from "vitest";
 import { TSGhostAdminAPI } from "../admin-api";
 
 const stub = {

--- a/packages/ts-ghost-admin-api/src/schemas/posts.integration.test.ts
+++ b/packages/ts-ghost-admin-api/src/schemas/posts.integration.test.ts
@@ -225,11 +225,9 @@ describe("posts integration tests browse", () => {
     expect(api.posts).toBeDefined();
     const result = await api.posts
       .browse({
-        input: { limit: 1 },
-        output: {
-          formats: ["html", "plaintext"],
-        },
+        limit: 1,
       })
+      .formats({ html: true, plaintext: true })
       .fetch();
 
     assert(result.status === "success");
@@ -344,11 +342,9 @@ describe("posts integration tests browse", () => {
     expect(api.posts).toBeDefined();
     const result = await api.posts
       .read({
-        input: { slug: "coming-soon" },
-        output: {
-          formats: ["html", "plaintext"],
-        },
+        slug: "coming-soon",
       })
+      .formats({ html: true, plaintext: true })
       .fetch();
 
     assert(result.status === "success");
@@ -468,21 +464,17 @@ describe("posts integration tests browse", () => {
     expect(api.posts).toBeDefined();
     const result = await api.posts
       .browse({
-        input: { limit: 1 },
-        output: {
-          formats: ["html", "plaintext"],
-        },
+        limit: 1,
       })
+      .formats({ html: true, plaintext: true })
       .fetch();
     assert(result.status === "error");
     expect(result.errors[0].message).toBe("Unknown Admin API Key");
     const resultR = await api.posts
       .read({
-        input: { slug: "coming-soon" },
-        output: {
-          formats: ["html", "plaintext"],
-        },
+        slug: "coming-soon",
       })
+      .formats({ html: true, plaintext: true })
       .fetch();
     assert(resultR.status === "error");
     expect(resultR.errors[0].message).toBe("Unknown Admin API Key");
@@ -497,21 +489,17 @@ describe("posts integration tests browse", () => {
     expect(api.posts).toBeDefined();
     const result = await api.posts
       .browse({
-        input: { limit: 1 },
-        output: {
-          formats: ["html", "plaintext"],
-        },
+        limit: 1,
       })
+      .formats({ html: true, plaintext: true })
       .fetch();
     assert(result.status === "error");
     expect(result.errors[0].message).toContain("FetchError");
     const resultR = await api.posts
       .read({
-        input: { slug: "coming-soon" },
-        output: {
-          formats: ["html", "plaintext"],
-        },
+        slug: "coming-soon",
       })
+      .formats({ html: true, plaintext: true })
       .fetch();
     assert(resultR.status === "error");
     expect(resultR.errors[0].message).toContain("FetchError");

--- a/packages/ts-ghost-admin-api/src/schemas/site.integration.test.ts
+++ b/packages/ts-ghost-admin-api/src/schemas/site.integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, beforeEach, assert } from "vitest";
+import { describe, test, beforeEach, assert, expect } from "vitest";
 import { TSGhostAdminAPI } from "../admin-api";
 
 const stubSite = {

--- a/packages/ts-ghost-admin-api/src/schemas/tags.integration.test.ts
+++ b/packages/ts-ghost-admin-api/src/schemas/tags.integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, beforeEach, assert } from "vitest";
+import { describe, test, beforeEach, assert, expect } from "vitest";
 import { TSGhostAdminAPI } from "../admin-api";
 
 const stubResult = {

--- a/packages/ts-ghost-admin-api/src/schemas/tags.integration.test.ts
+++ b/packages/ts-ghost-admin-api/src/schemas/tags.integration.test.ts
@@ -46,7 +46,7 @@ describe("tags integration tests browse", () => {
     expect(api.tags).toBeDefined();
     const result = await api.tags
       .browse({
-        input: { limit: 1 },
+        limit: 1,
       })
       .fetch();
 
@@ -80,7 +80,7 @@ describe("tags integration tests browse", () => {
     expect(api.tags).toBeDefined();
     const result = await api.tags
       .read({
-        input: { id: "63887bd07f2cf30001fec7a5" },
+        id: "63887bd07f2cf30001fec7a5",
       })
       .fetch();
     assert(result.status === "success");

--- a/packages/ts-ghost-admin-api/src/schemas/tiers.integration.test.ts
+++ b/packages/ts-ghost-admin-api/src/schemas/tiers.integration.test.ts
@@ -58,7 +58,7 @@ describe("tiers integration tests browse", () => {
     expect(api.tiers).toBeDefined();
     const result = await api.tiers
       .browse({
-        input: { limit: 1 },
+        limit: 1,
       })
       .fetch();
 
@@ -85,7 +85,7 @@ describe("tiers integration tests browse", () => {
     expect(api.tiers).toBeDefined();
     const result = await api.tiers
       .read({
-        input: { id: "63887bd07f2cf30001fec7a2" },
+        id: "63887bd07f2cf30001fec7a2",
       })
       .fetch();
     assert(result.status === "success");

--- a/packages/ts-ghost-admin-api/src/schemas/tiers.integration.test.ts
+++ b/packages/ts-ghost-admin-api/src/schemas/tiers.integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, beforeEach, assert } from "vitest";
+import { describe, test, beforeEach, assert, expect } from "vitest";
 import { TSGhostAdminAPI } from "../admin-api";
 
 const stubResult = {

--- a/packages/ts-ghost-admin-api/src/schemas/users.integration.test.ts
+++ b/packages/ts-ghost-admin-api/src/schemas/users.integration.test.ts
@@ -51,7 +51,7 @@ describe("users integration tests browse", () => {
     expect(api.users).toBeDefined();
     const result = await api.users
       .browse({
-        input: { limit: 1 },
+        limit: 1,
       })
       .fetch();
 
@@ -87,7 +87,7 @@ describe("users integration tests browse", () => {
     expect(api.users).toBeDefined();
     const result = await api.users
       .read({
-        input: { id: "1" },
+        id: "1",
       })
       .fetch();
     assert(result.status === "success");

--- a/packages/ts-ghost-admin-api/src/schemas/users.integration.test.ts
+++ b/packages/ts-ghost-admin-api/src/schemas/users.integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, beforeEach, assert } from "vitest";
+import { describe, test, beforeEach, assert, expect } from "vitest";
 import { TSGhostAdminAPI } from "../admin-api";
 
 const stubResult = {

--- a/packages/ts-ghost-content-api/README.md
+++ b/packages/ts-ghost-content-api/README.md
@@ -101,9 +101,9 @@ let query = api.posts.browse({
 
 ### `.browse` options
 
-Input are totally optionals on the `browse` method but they let you filter and order your search.
+Params are totally optionals on the `browse` method but they let you filter and order your search.
 
-This is an example containing all the available keys in the `input` object
+This is an example containing all the available keys in the params object
 
 ```typescript
 let query = api.posts.browse({
@@ -382,17 +382,14 @@ const order = "foobar DESC";
 const input = { order } as BrowseParams<{ order: string }, Post>;
 const result = await api.posts
   .browse({
-    input: {
-      order,
-    },
+    order,
   })
   .fetch();
 ```
 
 ## Roadmap
 
-- [x] Write more docs
-- [ ] Better handling of weird Ghost "include" params in API call
+- [ ] Write more tests
 
 ## Contributing
 

--- a/packages/ts-ghost-content-api/package.json
+++ b/packages/ts-ghost-content-api/package.json
@@ -41,7 +41,8 @@
     "vite-tsconfig-paths": "^4.0.7",
     "vitest": "^0.29.7",
     "vitest-fetch-mock": "^0.2.2",
-    "zod": "^3.20.6"
+    "zod": "^3.20.6",
+    "cross-fetch": "^3.1.5"
   },
   "dependencies": {
     "@ts-ghost/core-api": "^0.3.2",

--- a/packages/ts-ghost-content-api/src/authors/authors.integration.test.ts
+++ b/packages/ts-ghost-content-api/src/authors/authors.integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach } from "vitest";
+import { describe, test, expect, beforeEach, assert } from "vitest";
 import { TSGhostContentAPI } from "../content-api";
 
 const url = process.env.VITE_GHOST_URL || "https://my-ghost-blog.com";

--- a/packages/ts-ghost-content-api/src/authors/authors.integration.test.ts
+++ b/packages/ts-ghost-content-api/src/authors/authors.integration.test.ts
@@ -56,9 +56,9 @@ describe("authors integration tests browse", () => {
 
   test("authors.browse() with output", async () => {
     const result = await api.authors
-      .browse({
-        output: { fields: { id: true, name: true, slug: true, count: true }, include: { "count.posts": true } },
-      })
+      .browse()
+      .fields({ id: true, name: true, slug: true, count: true })
+      .include({ "count.posts": true })
       .fetch();
     expect(result).not.toBeUndefined();
     expect(result).not.toBeNull();
@@ -81,7 +81,7 @@ describe("authors integration tests browse", () => {
     expect(author.count?.posts).toBe(undefined);
   });
   test("authors.browse() with include count.posts", async () => {
-    const result = await api.authors.browse({ output: { include: { "count.posts": true } } }).fetch();
+    const result = await api.authors.browse().include({ "count.posts": true }).fetch();
     expect(result).not.toBeUndefined();
     expect(result).not.toBeNull();
     if (result.status === "error") {
@@ -105,7 +105,7 @@ describe("authors integration tests read", () => {
   const api = new TSGhostContentAPI(url, key, "v5.0");
 
   test("should fetch one author correctly by id", async () => {
-    const readQuery = api.authors.read({ input: { id: "1" } });
+    const readQuery = api.authors.read({ id: "1" });
     expect(readQuery).not.toBeUndefined();
     expect(readQuery.getParams().fields).toBeUndefined();
     expect(readQuery.getURL()?.searchParams.toString()).toBeDefined();
@@ -126,7 +126,7 @@ describe("authors integration tests read", () => {
   });
 
   test("should fetch one author correctly by slug", async () => {
-    const readQuery = api.authors.read({ input: { slug: "phildl" } });
+    const readQuery = api.authors.read({ slug: "phildl" });
     expect(readQuery).not.toBeUndefined();
     expect(readQuery.getParams().fields).toBeUndefined();
     expect(readQuery.getURL()?.searchParams.toString()).toBeDefined();
@@ -147,7 +147,7 @@ describe("authors integration tests read", () => {
   });
 
   test("should fetch author correctly and accept specific field", async () => {
-    const readQuery = api.authors.read({ input: { id: "1" }, output: { fields: { name: true } } });
+    const readQuery = api.authors.read({ id: "1" }).fields({ name: true });
     expect(readQuery).not.toBeUndefined();
     expect(readQuery.getParams()?.fields).toStrictEqual({
       name: true,
@@ -165,7 +165,7 @@ describe("authors integration tests read", () => {
   });
 
   test("should fetch author correctly and accept include", async () => {
-    const readQuery = api.authors.read({ input: { id: "1" }, output: { include: { "count.posts": true } } });
+    const readQuery = api.authors.read({ id: "1" }).include({ "count.posts": true });
     expect(readQuery).not.toBeUndefined();
     expect(readQuery.getParams()?.fields).toBeUndefined();
     expect(readQuery.getParams()?.include).toStrictEqual(["count.posts"]);
@@ -183,7 +183,7 @@ describe("authors integration tests read", () => {
   });
 
   test("should catch the case where author is not found", async () => {
-    const readQuery = api.authors.read({ input: { id: "32" } });
+    const readQuery = api.authors.read({ id: "32" });
     expect(readQuery).not.toBeUndefined();
     expect(readQuery.getParams().fields).toBeUndefined();
     expect(readQuery.getURL()?.searchParams.toString()).toBeDefined();

--- a/packages/ts-ghost-content-api/src/authors/authors.integration.test.ts
+++ b/packages/ts-ghost-content-api/src/authors/authors.integration.test.ts
@@ -149,9 +149,7 @@ describe("authors integration tests read", () => {
   test("should fetch author correctly and accept specific field", async () => {
     const readQuery = api.authors.read({ id: "1" }).fields({ name: true });
     expect(readQuery).not.toBeUndefined();
-    expect(readQuery.getParams()?.fields).toStrictEqual({
-      name: true,
-    });
+    expect(readQuery.getOutputFields()).toStrictEqual(["name"]);
     expect(readQuery.getURL()?.searchParams.toString()).toContain("&fields=name");
     const result = await readQuery.fetch();
     expect(result).not.toBeUndefined();

--- a/packages/ts-ghost-content-api/src/authors/authors.test.ts
+++ b/packages/ts-ghost-content-api/src/authors/authors.test.ts
@@ -9,40 +9,38 @@ describe("authors api .browse() Args Type-safety", () => {
   const api = new TSGhostContentAPI(url, key, "v5.0");
   test(".browse() params shouldnt accept invalid params", () => {
     // @ts-expect-error - shouldnt accept invalid params
-    const browse = api.authors.browse({ input: { pp: 2 } });
+    const browse = api.authors.browse({ pp: 2 });
     expect(browse.getParams().browseParams).toStrictEqual({});
   });
 
   test(".browse() 'order' params should ony accept fields values", () => {
     // @ts-expect-error - order should ony contain field
-    expect(() => api.authors.browse({ input: { order: "foo ASC" } })).toThrow();
+    expect(() => api.authors.browse({ order: "foo ASC" })).toThrow();
     // valid
-    expect(api.authors.browse({ input: { order: "name ASC" } }).getParams().browseParams).toStrictEqual({
+    expect(api.authors.browse({ order: "name ASC" }).getParams().browseParams).toStrictEqual({
       order: "name ASC",
     });
-    expect(api.authors.browse({ input: { order: "name ASC,slug DESC" } }).getParams().browseParams).toStrictEqual({
+    expect(api.authors.browse({ order: "name ASC,slug DESC" }).getParams().browseParams).toStrictEqual({
       order: "name ASC,slug DESC",
     });
-    expect(
-      api.authors.browse({ input: { order: "name ASC,slug DESC,location ASC" } }).getParams().browseParams
-    ).toStrictEqual({
+    expect(api.authors.browse({ order: "name ASC,slug DESC,location ASC" }).getParams().browseParams).toStrictEqual({
       order: "name ASC,slug DESC,location ASC",
     });
     // @ts-expect-error - order should ony contain field (There is a typo in location)
-    expect(() => api.authors.browse({ input: { order: "name ASC,slug DESC,locaton ASC" } })).toThrow();
+    expect(() => api.authors.browse({ order: "name ASC,slug DESC,locaton ASC" })).toThrow();
   });
 
   test(".browse() 'filter' params should ony accept valid field", () => {
     expect(() =>
       api.authors.browse({
         // @ts-expect-error - order should ony contain field
-        input: { filter: "foo:bar" },
+        filter: "foo:bar",
       })
     ).toThrow();
     expect(
       api.authors
         .browse({
-          input: { filter: "name:bar" },
+          filter: "name:bar",
         })
         .getParams().browseParams
     ).toStrictEqual({
@@ -51,7 +49,7 @@ describe("authors api .browse() Args Type-safety", () => {
     expect(
       api.authors
         .browse({
-          input: { filter: "name:bar+slug:-test" },
+          filter: "name:bar+slug:-test",
         })
         .getParams().browseParams
     ).toStrictEqual({
@@ -62,33 +60,16 @@ describe("authors api .browse() Args Type-safety", () => {
   test(".browse 'fields' argument should ony accept valid fields", () => {
     expect(
       api.authors
-        .browse({
-          output: {
-            // @ts-expect-error - order should ony contain field
-            fields: { foo: true },
-          },
+        .browse()
+        .fields({
+          // @ts-expect-error - order should ony contain field
+          foo: true,
         })
         .getOutputFields()
     ).toEqual([]);
 
-    expect(
-      api.authors
-        .browse({
-          output: {
-            fields: { location: true },
-          },
-        })
-        .getOutputFields()
-    ).toEqual(["location"]);
-    expect(
-      api.authors
-        .browse({
-          output: {
-            fields: { name: true, website: true },
-          },
-        })
-        .getOutputFields()
-    ).toEqual(["name", "website"]);
+    expect(api.authors.browse().fields({ location: true }).getOutputFields()).toEqual(["location"]);
+    expect(api.authors.browse().fields({ name: true, website: true }).getOutputFields()).toEqual(["name", "website"]);
   });
 });
 
@@ -110,20 +91,16 @@ describe("authors resource mocked", () => {
   test("aouthors should be fetched correctly", async () => {
     const authors = api.authors;
     expect(authors).not.toBeUndefined();
-    const browseQuery = authors.browse({
-      input: { page: 2 },
-      output: {
-        fields: {
-          name: true,
-          id: true,
-        },
-      },
-    });
+    const browseQuery = authors
+      .browse({
+        page: 2,
+      })
+      .fields({
+        name: true,
+        id: true,
+      });
     expect(browseQuery).not.toBeUndefined();
-    expect(browseQuery.getParams()?.fields).toStrictEqual({
-      name: true,
-      id: true,
-    });
+    expect(browseQuery.getOutputFields()).toStrictEqual(["name", "id"]);
     expect(browseQuery.getURL()?.searchParams.toString()).toBe(
       "key=59d4bf56c73c04a18c867dc3ba&page=2&fields=name%2Cid"
     );

--- a/packages/ts-ghost-content-api/src/pages/pages.integration.test.ts
+++ b/packages/ts-ghost-content-api/src/pages/pages.integration.test.ts
@@ -108,7 +108,7 @@ describe("pages integration tests browse", () => {
   });
 
   test("pages.browse() include authors and tags", async () => {
-    const result = await api.pages.browse({ output: { include: { authors: true, tags: true } } }).fetch();
+    const result = await api.pages.browse().include({ authors: true, tags: true }).fetch();
     expect(result).not.toBeUndefined();
     expect(result).not.toBeNull();
     if (result.status === "error") {
@@ -132,13 +132,7 @@ describe("pages integration tests browse", () => {
   });
 
   test("pages.browse() with mix of incude and fields... this is mostly broken on Ghost side", async () => {
-    const result = await api.pages
-      .browse({
-        output: {
-          fields: { slug: true, title: true },
-        },
-      })
-      .fetch();
+    const result = await api.pages.browse().fields({ slug: true, title: true }).fetch();
     expect(result).not.toBeUndefined();
     expect(result).not.toBeNull();
     if (result.status === "error") {
@@ -159,12 +153,9 @@ describe("pages integration tests browse", () => {
 
   test("pages.browse() with mix of incude and fields... this is mostly broken on Ghost side", async () => {
     const result = await api.pages
-      .browse({
-        output: {
-          fields: { slug: true, title: true, primary_author: true },
-          include: { authors: true },
-        },
-      })
+      .browse()
+      .fields({ slug: true, title: true, primary_author: true })
+      .include({ authors: true })
       .fetch();
     expect(result).not.toBeUndefined();
     expect(result).not.toBeNull();
@@ -194,7 +185,7 @@ describe("pages integration tests read", () => {
   });
 
   test("pages.browse() include authors and tags", async () => {
-    const result = await api.pages.read({ input: { id: "63887bd07f2cf30001fec812" } }).fetch();
+    const result = await api.pages.read({ id: "63887bd07f2cf30001fec812" }).fetch();
     expect(result).not.toBeUndefined();
     expect(result).not.toBeNull();
     if (result.status === "error") {

--- a/packages/ts-ghost-content-api/src/posts/posts.integration.test.ts
+++ b/packages/ts-ghost-content-api/src/posts/posts.integration.test.ts
@@ -101,7 +101,7 @@ describe("posts integration tests browse", () => {
   });
 
   test("posts.browse() include authors and tags", async () => {
-    const result = await api.posts.browse({ output: { include: { authors: true, tags: true } } }).fetch();
+    const result = await api.posts.browse().include({ authors: true, tags: true }).fetch();
     expect(result).not.toBeUndefined();
     expect(result).not.toBeNull();
     if (result.status === "error") {
@@ -129,13 +129,7 @@ describe("posts integration tests browse", () => {
       slug: true,
       title: true,
     } satisfies { [k in keyof Post]?: true | undefined };
-    const result = await api.posts
-      .browse({
-        output: {
-          fields: outputFields,
-        },
-      })
-      .fetch();
+    const result = await api.posts.browse().fields(outputFields).fetch();
     expect(result).not.toBeUndefined();
     expect(result).not.toBeNull();
     if (result.status === "error") {
@@ -156,12 +150,9 @@ describe("posts integration tests browse", () => {
 
   test("posts.browse() with mix of incude and fields... this is mostly broken on Ghost side", async () => {
     const result = await api.posts
-      .browse({
-        output: {
-          fields: { slug: true, title: true, primary_author: true },
-          include: { authors: true },
-        },
-      })
+      .browse()
+      .fields({ slug: true, title: true, primary_author: true })
+      .include({ authors: true })
       .fetch();
     expect(result).not.toBeUndefined();
     expect(result).not.toBeNull();
@@ -191,7 +182,7 @@ describe("posts integration tests read", () => {
   });
 
   test("posts.browse() include authors and tags", async () => {
-    const result = await api.posts.read({ input: { id: "63887bd07f2cf30001fec812" } }).fetch();
+    const result = await api.posts.read({ id: "63887bd07f2cf30001fec812" }).fetch();
     expect(result).not.toBeUndefined();
     expect(result).not.toBeNull();
     if (result.status === "error") {

--- a/packages/ts-ghost-content-api/src/posts/posts.test.ts
+++ b/packages/ts-ghost-content-api/src/posts/posts.test.ts
@@ -8,7 +8,7 @@ describe("posts api .browse() Args Type-safety", () => {
   const api = new TSGhostContentAPI(url, key, "v5.0");
   test(".browse() params shouldnt accept invalid params", () => {
     // @ts-expect-error - shouldnt accept invalid params
-    const browse = api.posts.browse({ input: { pp: 2 } });
+    const browse = api.posts.browse({ pp: 2 });
     expect(browse.getParams().browseParams).toStrictEqual({});
 
     const outputFields = {
@@ -18,12 +18,10 @@ describe("posts api .browse() Args Type-safety", () => {
       foo: true,
     } satisfies { [k in keyof Post]?: true | undefined };
 
-    let test = api.posts.browse({
-      output: {
-        // @ts-expect-error - shouldnt accept invalid params
-        fields: outputFields,
-      },
-    });
+    let test = api.posts
+      .browse()
+      // @ts-expect-error - shouldnt accept invalid params
+      .fields(outputFields);
     expect(test.getOutputFields()).toEqual(["slug", "title"]);
 
     const fields = ["slug", "title", "foo"] as const;
@@ -31,11 +29,7 @@ describe("posts api .browse() Args Type-safety", () => {
       acc[k as keyof Post] = true;
       return acc;
     }, {} as { [k in keyof Post]?: true | undefined });
-    const result = api.posts.browse({
-      output: {
-        fields: unknownOriginFields,
-      },
-    });
+    const result = api.posts.browse().fields(unknownOriginFields);
     expect(result.getOutputFields()).toEqual(["slug", "title"]);
   });
   test(".browse() params, output fields declare const", () => {
@@ -44,11 +38,7 @@ describe("posts api .browse() Args Type-safety", () => {
       title: true,
     } satisfies { [k in keyof Post]?: true | undefined };
 
-    let test = api.posts.browse({
-      output: {
-        fields: outputFields,
-      },
-    });
+    let test = api.posts.browse().fields(outputFields);
     expect(test.getOutputFields()).toEqual(["slug", "title"]);
   });
 });

--- a/packages/ts-ghost-content-api/src/tags/tags.integration.test.ts
+++ b/packages/ts-ghost-content-api/src/tags/tags.integration.test.ts
@@ -70,7 +70,7 @@ describe("tags integration tests browse", () => {
   });
 
   test("tags.browse() include authors and tags", async () => {
-    const result = await api.tags.browse({ output: { include: { "count.posts": true } } }).fetch();
+    const result = await api.tags.browse().include({ "count.posts": true }).fetch();
     expect(result).not.toBeUndefined();
     expect(result).not.toBeNull();
     if (result.status === "error") {
@@ -86,13 +86,7 @@ describe("tags integration tests browse", () => {
   });
 
   test("tags.browse() with mix of incude and fields... this is mostly broken on Ghost side", async () => {
-    const result = await api.tags
-      .browse({
-        output: {
-          fields: { slug: true, name: true },
-        },
-      })
-      .fetch();
+    const result = await api.tags.browse().fields({ slug: true, name: true }).fetch();
     expect(result).not.toBeUndefined();
     expect(result).not.toBeNull();
     if (result.status === "error") {
@@ -113,12 +107,9 @@ describe("tags integration tests browse", () => {
 
   test("tags.browse() with mix of incude and fields... this is mostly broken on Ghost side", async () => {
     const result = await api.tags
-      .browse({
-        output: {
-          fields: { slug: true, name: true, count: true },
-          include: { "count.posts": true },
-        },
-      })
+      .browse()
+      .fields({ slug: true, name: true, count: true })
+      .include({ "count.posts": true })
       .fetch();
     expect(result).not.toBeUndefined();
     expect(result).not.toBeNull();
@@ -148,7 +139,7 @@ describe("tags integration tests read", () => {
   });
 
   test("tags.read() by id", async () => {
-    const result = await api.tags.read({ input: { id: "63887bd07f2cf30001fec812" } }).fetch();
+    const result = await api.tags.read({ id: "63887bd07f2cf30001fec812" }).fetch();
     expect(result).not.toBeUndefined();
     expect(result).not.toBeNull();
     if (result.status === "error") {
@@ -183,7 +174,7 @@ describe("tags integration tests read", () => {
   });
 
   test("tags.read() by slug", async () => {
-    const result = await api.tags.read({ input: { slug: "news" } }).fetch();
+    const result = await api.tags.read({ slug: "news" }).fetch();
     expect(result).not.toBeUndefined();
     expect(result).not.toBeNull();
     if (result.status === "error") {
@@ -218,9 +209,7 @@ describe("tags integration tests read", () => {
   });
 
   test("tags.read() by slug with fields", async () => {
-    const result = await api.tags
-      .read({ input: { slug: "news" }, output: { fields: { name: true, id: true } } })
-      .fetch();
+    const result = await api.tags.read({ slug: "news" }).fields({ name: true, id: true }).fetch();
     expect(result).not.toBeUndefined();
     expect(result).not.toBeNull();
     if (result.status === "error") {
@@ -240,9 +229,7 @@ describe("tags integration tests read", () => {
   });
 
   test("tags.read() with count", async () => {
-    const result = await api.tags
-      .read({ input: { slug: "news" }, output: { include: { "count.posts": true } } })
-      .fetch();
+    const result = await api.tags.read({ slug: "news" }).include({ "count.posts": true }).fetch();
     expect(result).not.toBeUndefined();
     expect(result).not.toBeNull();
     if (result.status === "error") {

--- a/packages/ts-ghost-content-api/src/tiers/tiers.integration.test.ts
+++ b/packages/ts-ghost-content-api/src/tiers/tiers.integration.test.ts
@@ -72,7 +72,8 @@ describe("tiers integration tests browse", () => {
 
   test("tiers.browse() include authors and tiers", async () => {
     const result = await api.tiers
-      .browse({ output: { include: { benefits: true, monthly_price: true, yearly_price: true } } })
+      .browse()
+      .include({ benefits: true, monthly_price: true, yearly_price: true })
       .fetch();
     expect(result).not.toBeUndefined();
     expect(result).not.toBeNull();
@@ -89,13 +90,7 @@ describe("tiers integration tests browse", () => {
   });
 
   test("tiers.browse() with mix of incude and fields... ghost doesn't answer to that query", async () => {
-    const result = await api.tiers
-      .browse({
-        output: {
-          fields: { slug: true, name: true },
-        },
-      })
-      .fetch();
+    const result = await api.tiers.browse().fields({ slug: true, name: true }).fetch();
     expect(result).not.toBeUndefined();
     expect(result).not.toBeNull();
     // Right now this doesn't work in Ghost API
@@ -103,14 +98,7 @@ describe("tiers integration tests browse", () => {
   });
 
   test("tiers.browse() with mix of incude and fields... this is mostly broken on Ghost side", async () => {
-    const result = await api.tiers
-      .browse({
-        output: {
-          fields: { slug: true, name: true },
-          include: { monthly_price: true },
-        },
-      })
-      .fetch();
+    const result = await api.tiers.browse().include({ monthly_price: true }).fields({ slug: true, name: true }).fetch();
     expect(result).not.toBeUndefined();
     expect(result).not.toBeNull();
     expect(result.status).toBe("error");
@@ -124,14 +112,14 @@ describe("tiers integration tests read doesn't work on GHOST API", () => {
   });
 
   test("tiers.read() by id doesn't work on ghost", async () => {
-    const result = await api.tiers.read({ input: { id: "63887bd07f2cf30001fec7a2" } }).fetch();
+    const result = await api.tiers.read({ id: "63887bd07f2cf30001fec7a2" }).fetch();
     expect(result).not.toBeUndefined();
     expect(result).not.toBeNull();
     expect(result.status).toBe("error");
   });
 
   test("tiers.read() by slug", async () => {
-    const result = await api.tiers.read({ input: { slug: "free" } }).fetch();
+    const result = await api.tiers.read({ slug: "free" }).fetch();
     expect(result).not.toBeUndefined();
     expect(result).not.toBeNull();
     expect(result.status).toBe("error");

--- a/packages/ts-ghost-core-api/README.md
+++ b/packages/ts-ghost-core-api/README.md
@@ -160,7 +160,7 @@ If the parsing went okay, the `read` and `browse` methods from the `QueryBuilder
 - `ReadFetcher` for the `read` method
 - `BasicFetcher` is a special case when you don't need a QueryBuilder at all and want to fetch directly. 
 
-These Fetchers are instantiated in a similar way as the QueryBuilder with a `config` containing the same schemas. But also a set of params 
+Fetchers are instatiated automatically after using `read` or `browse` but these Fetchers can also be instantiated in isolation, in a similar way as the QueryBuilder with a `config` containing the same schemas. But also a set of params 
 necessary to build the URL to the Ghost API.
 
 ```typescript
@@ -189,7 +189,7 @@ const qb = new QueryBuilder(
   { schema: simplifiedSchema, output: simplifiedSchema, include: simplifiedIncludeSchema },
   api
 );
-const readFetcher = qb.read({input: {slug: "typescript-is-cool"}});
+const readFetcher = qb.read({ slug: "typescript-is-cool" });
 let result = await readFetcher.fetch();
 if (result.status === 'success') {
   const post = result.data;
@@ -378,8 +378,7 @@ let result = await bf.fields({
 
 ## Roadmap
 
-- Write more docs
-- Better handling of weird Ghost "include" params in API call
+- Handling POST, PUT and DELETE requests.
 
 ## Contributing
 

--- a/packages/ts-ghost-core-api/src/fetchers/browse-fetcher.test.ts
+++ b/packages/ts-ghost-core-api/src/fetchers/browse-fetcher.test.ts
@@ -420,7 +420,7 @@ describe("BrowseFetcher", () => {
   });
 });
 
-describe("BrowseFetcher v2", () => {
+describe("BrowseFetcher output tests suite", () => {
   const api: ContentAPICredentials = {
     url: "https://ghost.org",
     key: "1234",
@@ -441,6 +441,7 @@ describe("BrowseFetcher v2", () => {
 
   const simplifiedIncludeSchema = z.object({
     count: z.literal(true).optional(),
+    "nested.key": z.literal(true).optional(),
   });
 
   beforeEach(() => {
@@ -503,13 +504,13 @@ describe("BrowseFetcher v2", () => {
     );
     const res = fetcher
       .formats({ html: true })
-      .include({ count: true })
+      .include({ count: true, "nested.key": true })
       .fields({ html: true, published: true, count: true });
-    expect(res.getIncludes()).toStrictEqual(["count"]);
+    expect(res.getIncludes()).toStrictEqual(["count", "nested.key"]);
     expect(res.getOutputFields()).toStrictEqual(["html", "published", "count"]);
     expect(res.getFormats()).toStrictEqual(["html"]);
     expect(res.getURL()?.toString().replace("https://ghost.org/ghost/api/content/posts/", "")).toBe(
-      "?key=1234&fields=html%2Cpublished%2Ccount&include=count&formats=html"
+      "?key=1234&fields=html%2Cpublished%2Ccount&include=count%2Cnested.key&formats=html"
     );
   });
   test("new formats, fields, and include should indicate wrong fields", async () => {

--- a/packages/ts-ghost-core-api/src/fetchers/browse-fetcher.ts
+++ b/packages/ts-ghost-core-api/src/fetchers/browse-fetcher.ts
@@ -69,9 +69,7 @@ export class BrowseFetcher<
    * @param include Include specific keys from the include shape
    * @returns A new Fetcher with the fixed output shape and the formats specified
    */
-  public include<Includes extends Mask<Pick<OutputShape, Extract<keyof IncludeShape, keyof OutputShape>>>>(
-    include: z.noUnrecognized<Includes, OutputShape>
-  ) {
+  public include<Includes extends Mask<IncludeShape>>(include: z.noUnrecognized<Includes, IncludeShape>) {
     const params = {
       ...this._params,
       include: Object.keys(this.config.include.parse(include)),

--- a/packages/ts-ghost-core-api/src/fetchers/read-fetcher.test.ts
+++ b/packages/ts-ghost-core-api/src/fetchers/read-fetcher.test.ts
@@ -349,7 +349,7 @@ describe("ReadFetcherFetcher outputs test suite", () => {
     expect(res.getOutputFields()).toStrictEqual(["html", "published", "count"]);
     expect(res.getFormats()).toStrictEqual(["html"]);
     expect(res.getURL()?.toString().replace("https://ghost.org/ghost/api/content/posts/slug/this-is-a-slug/", "")).toBe(
-      "?key=1234&fields=html%2Cpublished%2Ccount&include=count&formats=html"
+      "?key=1234&fields=html%2Cpublished%2Ccount&include=count%2Cnested.key&formats=html"
     );
   });
   test("new formats, fields, and include should indicate wrong fields", async () => {

--- a/packages/ts-ghost-core-api/src/fetchers/read-fetcher.test.ts
+++ b/packages/ts-ghost-core-api/src/fetchers/read-fetcher.test.ts
@@ -296,7 +296,7 @@ describe("ReadFetcher", () => {
     expect(fetcher.getIncludes()).toEqual([]);
   });
 });
-describe("ReadFetcherFetcher v2", () => {
+describe("ReadFetcherFetcher outputs test suite", () => {
   const api: ContentAPICredentials = {
     url: "https://ghost.org",
     key: "1234",
@@ -317,6 +317,7 @@ describe("ReadFetcherFetcher v2", () => {
 
   const simplifiedIncludeSchema = z.object({
     count: z.literal(true).optional(),
+    "nested.key": z.literal(true).optional(),
   });
 
   beforeEach(() => {
@@ -342,9 +343,9 @@ describe("ReadFetcherFetcher v2", () => {
     );
     const res = fetcher
       .formats({ html: true })
-      .include({ count: true })
+      .include({ count: true, "nested.key": true })
       .fields({ html: true, published: true, count: true });
-    expect(res.getIncludes()).toStrictEqual(["count"]);
+    expect(res.getIncludes()).toStrictEqual(["count", "nested.key"]);
     expect(res.getOutputFields()).toStrictEqual(["html", "published", "count"]);
     expect(res.getFormats()).toStrictEqual(["html"]);
     expect(res.getURL()?.toString().replace("https://ghost.org/ghost/api/content/posts/slug/this-is-a-slug/", "")).toBe(

--- a/packages/ts-ghost-core-api/src/fetchers/read-fetcher.ts
+++ b/packages/ts-ghost-core-api/src/fetchers/read-fetcher.ts
@@ -67,9 +67,7 @@ export class ReadFetcher<
    * @param include Include specific keys from the include shape
    * @returns A new Fetcher with the fixed output shape and the formats specified
    */
-  public include<Includes extends Mask<Pick<OutputShape, Extract<keyof IncludeShape, keyof OutputShape>>>>(
-    include: z.noUnrecognized<Includes, OutputShape>
-  ) {
+  public include<Includes extends Mask<IncludeShape>>(include: z.noUnrecognized<Includes, IncludeShape>) {
     const params = {
       ...this._params,
       include: Object.keys(this.config.include.parse(include)),

--- a/packages/ts-ghost-core-api/src/query-builder/query-builder.test.ts
+++ b/packages/ts-ghost-core-api/src/query-builder/query-builder.test.ts
@@ -35,17 +35,15 @@ describe("QueryBuilder", () => {
     expect(qb.browse()).toBeInstanceOf(BrowseFetcher);
     // @ts-expect-error - missing Identity fields
     expect(() => qb.read()).toThrow();
-    expect(qb.read({ input: { id: "abc" } })).toBeInstanceOf(ReadFetcher);
+    expect(qb.read({ id: "abc" })).toBeInstanceOf(ReadFetcher);
   });
 
   describe("pagination inputs", () => {
     test("pagination params", () => {
       expect(
         qb.browse({
-          input: {
-            limit: 10,
-            page: 2,
-          },
+          limit: 10,
+          page: 2,
         })
       ).toBeInstanceOf(BrowseFetcher);
     });
@@ -53,16 +51,12 @@ describe("QueryBuilder", () => {
     test("pagination params shouldn't accept limit over 15 or under 0", () => {
       expect(() =>
         qb.browse({
-          input: {
-            limit: 20,
-          },
+          limit: 20,
         })
       ).toThrow();
       expect(() =>
         qb.browse({
-          input: {
-            limit: -1,
-          },
+          limit: -1,
         })
       ).toThrow();
     });
@@ -70,9 +64,7 @@ describe("QueryBuilder", () => {
     test("pagination params shouldn't accept page under 1", () => {
       expect(() =>
         qb.browse({
-          input: {
-            page: 0,
-          },
+          page: 0,
         })
       ).toThrow();
     });
@@ -82,9 +74,7 @@ describe("QueryBuilder", () => {
     test("order params should accept a string with correct fields", () => {
       expect(
         qb.browse({
-          input: {
-            order: "foo desc",
-          },
+          order: "foo desc",
         })
       ).toBeInstanceOf(BrowseFetcher);
     });
@@ -92,10 +82,8 @@ describe("QueryBuilder", () => {
     test("order params should not accept incorrect fields", () => {
       expect(() =>
         qb.browse({
-          input: {
-            // @ts-expect-error - invalid field
-            order: "foobarbaz desc",
-          },
+          // @ts-expect-error - invalid field
+          order: "foobarbaz desc",
         })
       ).toThrow();
     });
@@ -103,11 +91,7 @@ describe("QueryBuilder", () => {
     test("order params should be possible to be declared as const", () => {
       const order = "foo DESC";
       const input = { order } satisfies BrowseParams<{ order: typeof order }, z.infer<typeof simplifiedSchema>>;
-      expect(
-        qb.browse({
-          input: input,
-        })
-      ).toBeInstanceOf(BrowseFetcher);
+      expect(qb.browse(input)).toBeInstanceOf(BrowseFetcher);
     });
 
     test("order params should be possible to be declared as const and be type-safe", () => {
@@ -115,21 +99,17 @@ describe("QueryBuilder", () => {
       // @ts-expect-error - invalid field
       const input = { order } satisfies BrowseParams<{ order: typeof order }, z.infer<typeof simplifiedSchema>>;
       expect(() =>
-        qb.browse({
+        qb.browse(
           // @ts-expect-error - invalid field
-          input: input,
-        })
+          input
+        )
       ).toThrow();
     });
 
     test("order params should be possible to be declared without type-safety but still throw", () => {
       const order = "foobar DESC";
       const input = { order } as BrowseParams<{ order: string }, z.infer<typeof simplifiedSchema>>;
-      expect(() =>
-        qb.browse({
-          input: input,
-        })
-      ).toThrow();
+      expect(() => qb.browse(input)).toThrow();
     });
   });
 
@@ -137,9 +117,7 @@ describe("QueryBuilder", () => {
     test("filter params should accept a string with correct fields", () => {
       expect(
         qb.browse({
-          input: {
-            filter: "foo:test",
-          },
+          filter: "foo:test",
         })
       ).toBeInstanceOf(BrowseFetcher);
     });
@@ -147,10 +125,8 @@ describe("QueryBuilder", () => {
     test("filter params should not accept incorrect fields", () => {
       expect(() =>
         qb.browse({
-          input: {
-            // @ts-expect-error - invalid field
-            filter: "fo:test",
-          },
+          // @ts-expect-error - invalid field
+          filter: "fo:test",
         })
       ).toThrow();
     });
@@ -158,11 +134,7 @@ describe("QueryBuilder", () => {
     test("filter params should be possible to be declared as const", () => {
       const filter = "foo:bar";
       const input = { filter } satisfies BrowseParams<{ filter: typeof filter }, z.infer<typeof simplifiedSchema>>;
-      expect(
-        qb.browse({
-          input: input,
-        })
-      ).toBeInstanceOf(BrowseFetcher);
+      expect(qb.browse(input)).toBeInstanceOf(BrowseFetcher);
     });
 
     test("filter params should be possible to be declared as const and be type-safe", () => {
@@ -170,21 +142,17 @@ describe("QueryBuilder", () => {
       // @ts-expect-error - invalid field
       const input = { filter } satisfies BrowseParams<{ filter: typeof filter }, z.infer<typeof simplifiedSchema>>;
       expect(() =>
-        qb.browse({
+        qb.browse(
           // @ts-expect-error - invalid field
-          input: input,
-        })
+          input
+        )
       ).toThrow();
     });
 
     test("filter params should be possible to be declared without type-safety but still throw", () => {
       const filter = "foobar:test";
       const input = { filter } as BrowseParams<{ filter: string }, z.infer<typeof simplifiedSchema>>;
-      expect(() =>
-        qb.browse({
-          input: input,
-        })
-      ).toThrow();
+      expect(() => qb.browse(input)).toThrow();
     });
   });
 
@@ -192,17 +160,13 @@ describe("QueryBuilder", () => {
     test("identity read fields params should only accept key from the identity read schema", () => {
       expect(
         qb.read({
-          input: {
-            id: "abc",
-          },
+          id: "abc",
         })
       ).toBeInstanceOf(ReadFetcher);
 
       expect(
         qb.read({
-          input: {
-            slug: "foo-bar",
-          },
+          slug: "foo-bar",
         })
       ).toBeInstanceOf(ReadFetcher);
     });
@@ -210,10 +174,8 @@ describe("QueryBuilder", () => {
     test("identity read fields params should only accept key from the identity read schema", () => {
       expect(() =>
         qb.read({
-          input: {
-            // @ts-expect-error - invalid field
-            foo: "foobarbaz",
-          },
+          // @ts-expect-error - invalid field
+          foo: "foobarbaz",
         })
       ).toThrow();
     });
@@ -221,169 +183,8 @@ describe("QueryBuilder", () => {
 
   describe("include output", () => {
     test("include params should only accept key from the include schema", () => {
-      expect(
-        qb.browse({
-          output: {
-            include: {
-              count: true,
-            },
-          },
-        })
-      ).toBeInstanceOf(BrowseFetcher);
-      expect(
-        qb.read({
-          input: { id: "abc" },
-          output: {
-            include: {
-              count: true,
-            },
-          },
-        })
-      ).toBeInstanceOf(ReadFetcher);
-    });
-
-    test("include params should only accept key from the include schema", () => {
-      expect(
-        qb
-          .browse({
-            output: {
-              include: {
-                // @ts-expect-error - invalid field
-                foobarbaz: true,
-              },
-            },
-          })
-          .getIncludes()
-      ).toStrictEqual([]);
-      expect(
-        qb
-          .read({
-            input: {
-              id: "abc",
-            },
-            output: {
-              include: {
-                // @ts-expect-error - invalid field
-                foobarbaz: true,
-              },
-            },
-          })
-          .getIncludes()
-      ).toStrictEqual([]);
-    });
-  });
-
-  describe("fields output", () => {
-    test("fields params should only accept key from the fields schema", () => {
-      expect(
-        qb
-          .browse({
-            output: {
-              fields: {
-                foo: true,
-              },
-            },
-          })
-          .getOutputFields()
-      ).toStrictEqual(["foo"]);
-
-      expect(
-        qb
-          .read({
-            input: {
-              id: "abc",
-            },
-            output: {
-              fields: {
-                foo: true,
-              },
-            },
-          })
-          .getOutputFields()
-      ).toStrictEqual(["foo"]);
-    });
-
-    test("fields params should only accept key from the fields schema", () => {
-      expect(
-        qb
-          .browse({
-            output: {
-              fields: {
-                // @ts-expect-error - invalid field
-                foobarbaz: true,
-              },
-            },
-          })
-          .getOutputFields()
-      ).toStrictEqual([]);
-
-      expect(
-        qb
-          .read({
-            input: { id: "abc" },
-            output: {
-              fields: {
-                // @ts-expect-error - invalid field
-                foobarbaz: true,
-              },
-            },
-          })
-          .getOutputFields()
-      ).toStrictEqual([]);
-    });
-
-    test("fields should be okay with separate declaration", () => {
-      const outputFields = {
-        foo: true,
-      } satisfies { [k in keyof z.infer<typeof simplifiedSchema>]?: true | undefined };
-      expect(
-        qb
-          .browse({
-            output: {
-              fields: outputFields,
-            },
-          })
-          .getOutputFields()
-      ).toStrictEqual(["foo"]);
-    });
-
-    test("fields should be parsed even with type-safety overriden with as", () => {
-      const fields = ["slug", "title", "foo"];
-      const unknownOriginFields = fields.reduce((acc, k) => {
-        acc[k as keyof z.infer<typeof simplifiedSchema>] = true;
-        return acc;
-      }, {} as { [k in keyof z.infer<typeof simplifiedSchema>]?: true | undefined });
-      expect(
-        qb
-          .browse({
-            output: {
-              fields: unknownOriginFields,
-            },
-          })
-          .getOutputFields()
-      ).toStrictEqual(["foo"]);
-    });
-  });
-
-  describe("formats output", () => {
-    test("fields params should only accept key from the fields schema", () => {
-      const qb = new QueryBuilder(
-        {
-          schema: simplifiedSchema,
-          output: simplifiedSchema,
-          include: simplifiedIncludeSchema,
-          formats: z.array(z.enum(["html", "mobiledoc"])),
-        },
-        api
-      );
-      qb.read({
-        input: {
-          id: "tzojf",
-        },
-        output: {
-          formats: ["html", "mobiledoc"],
-        },
-      });
+      expect(qb.browse()).toBeInstanceOf(BrowseFetcher);
+      expect(qb.read({ id: "abc" })).toBeInstanceOf(ReadFetcher);
     });
   });
 });

--- a/packages/ts-ghost-core-api/src/query-builder/query-builder.ts
+++ b/packages/ts-ghost-core-api/src/query-builder/query-builder.ts
@@ -1,7 +1,7 @@
 import { parseBrowseParams } from "./browse-params";
 import type { BrowseParams } from "./browse-params";
 import type { APICredentials } from "../schemas";
-import { z, ZodEnum, ZodRawShape } from "zod";
+import { z, ZodRawShape } from "zod";
 import { BrowseFetcher } from "../fetchers/browse-fetcher";
 import { ReadFetcher } from "../fetchers/read-fetcher";
 import { queryIdentitySchema } from "../schemas";

--- a/packages/ts-ghost-core-api/src/query-builder/query-builder.ts
+++ b/packages/ts-ghost-core-api/src/query-builder/query-builder.ts
@@ -9,36 +9,27 @@ import { queryIdentitySchema } from "../schemas";
 export type OrderObjectKeyMask<Obj> = { [k in keyof Obj]?: "ASC" | "DESC" };
 
 /**
- * QueryBuilder class
- * @param {ZodRawShape} Shape
- * @param {ZodRawShape} OutputShape
- * @param {ZodRawShape} IncludeShape
- * @param {APICredentials} Api
- *
- * @returns {QueryBuilder} QueryBuilder
- *
+ * QueryBuilder class that accepts a schema and an API credentials object. It will return a class
+ * instance with browse and read functions.
  */
 export class QueryBuilder<
   Shape extends ZodRawShape,
   OutputShape extends ZodRawShape,
   IncludeShape extends ZodRawShape,
-  Api extends APICredentials,
-  Formats extends ZodEnum<[string, ...string[]]>
+  Api extends APICredentials
 > {
   constructor(
     protected config: {
       schema: z.ZodObject<Shape>;
       output: z.ZodObject<OutputShape>;
       include: z.ZodObject<IncludeShape>;
-      formats?: z.ZodArray<Formats, "many">;
     },
     protected _api: Api
   ) {}
 
   /**
-   * Browse function
-   * @param {}
-   * @returns
+   * Browse function that accepts browse params order, filter, page and limit. Will return an instance
+   * of BrowseFetcher class.
    */
   public browse<
     const OrderStr extends string,
@@ -64,9 +55,8 @@ export class QueryBuilder<
   }
 
   /**
-   * Browse function
-   * @param {}
-   * @returns
+   * Read function that accepts Identify fields like id, slug or email. Will return an instance
+   * of ReadFetcher class.
    */
   public read<
     Identity extends
@@ -74,7 +64,8 @@ export class QueryBuilder<
           id: string;
         }
       | { slug: string }
-  >(input: Identity) {
+      | { email: string }
+  >(options: Identity) {
     return new ReadFetcher(
       {
         schema: this.config.schema,
@@ -82,7 +73,7 @@ export class QueryBuilder<
         include: this.config.include,
       },
       {
-        identity: queryIdentitySchema.parse(input),
+        identity: queryIdentitySchema.parse(options),
       },
       this._api
     );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
     specifiers:
       '@clack/core': ^0.3.2
       '@clack/prompts': ^0.6.3
-      '@ts-ghost/admin-api': ^0.2.0
-      '@ts-ghost/content-api': ^0.3.0
+      '@ts-ghost/admin-api': ^0.2.2
+      '@ts-ghost/content-api': ^0.3.1
       '@ts-ghost/tsconfig': '*'
       '@types/configstore': ^6.0.0
       '@types/node': ^18.15.5
@@ -77,10 +77,11 @@ importers:
 
   packages/ts-ghost-admin-api:
     specifiers:
-      '@ts-ghost/core-api': ^0.3.1
+      '@ts-ghost/core-api': ^0.3.2
       '@ts-ghost/tsconfig': '*'
       '@types/node': ^18.15.5
       '@vitest/coverage-c8': ^0.29.7
+      cross-fetch: ^3.1.5
       eslint: ^8.36.0
       jiti: ^1.18.2
       tsup: ^6.7.0
@@ -96,6 +97,7 @@ importers:
       '@ts-ghost/tsconfig': link:../tsconfig
       '@types/node': 18.15.5
       '@vitest/coverage-c8': 0.29.7_vitest@0.29.7
+      cross-fetch: 3.1.5
       eslint: 8.36.0
       jiti: 1.18.2
       tsup: 6.7.0_typescript@5.0.2
@@ -106,10 +108,11 @@ importers:
 
   packages/ts-ghost-content-api:
     specifiers:
-      '@ts-ghost/core-api': ^0.3.0
+      '@ts-ghost/core-api': ^0.3.2
       '@ts-ghost/tsconfig': '*'
       '@types/node': ^18.15.5
       '@vitest/coverage-c8': ^0.29.7
+      cross-fetch: ^3.1.5
       eslint: ^8.36.0
       tsup: ^6.7.0
       typescript: 5.0.2
@@ -125,6 +128,7 @@ importers:
       '@ts-ghost/tsconfig': link:../tsconfig
       '@types/node': 18.15.5
       '@vitest/coverage-c8': 0.29.7_vitest@0.29.7
+      cross-fetch: 3.1.5
       eslint: 8.36.0
       tsup: 6.7.0_typescript@5.0.2
       typescript: 5.0.2


### PR DESCRIPTION
# Description

This PR removes the deprecated output params from the QueryBuilder `.browse` and `.read` methods

### Before 
```ts
const qb = new QueryBuilder(
  { schema: simplifiedSchema, output: simplifiedSchema, include: simplifiedIncludeSchema },
  api
);
let query = qb.browse({
  input: {
    limit: 5,
    order: "title DESC"
  },
  output: {
    include: {
      count: true,
      //  ^? Available inputs here come from the `simplifiedIncludeSchema`
    },
  },
});
```

### After
```ts
const qb = new QueryBuilder(
  { schema: simplifiedSchema, output: simplifiedSchema, include: simplifiedIncludeSchema },
  api
);
let query = qb.browse({
  limit: 5,
  order: "title DESC"
}).include({count: true});
```

## Checklist

### `ts-ghost/core-api`
- [x] Refactor QueryBuilder to only use input as parameters
- [x] tests passing
- [x] update documentation

### `ts-ghost/content-api`
- [x] tests passing
- [x] update documentation

### `ts-ghost/admin-api`
- [x] tests passing
- [x] update documentation

### Refactor `ts-ghost/ghost-blog-buster`
- [x] refactoring
- [x] update documentation if necessary

### Side projects
- [ ] Update astro-starter-ghost