### PR TITLE
Feature/qol and bugfixes

### DIFF
--- a/.changeset/lovely-dragons-own.md
+++ b/.changeset/lovely-dragons-own.md
@@ -2,4 +2,46 @@
 "@ts-ghost/core-api": minor
 ---
 
-Order predicate can now contains nested fields like "count.posts" plus new utility Types.
+## Browse params `order` and `filter` can now use keys from include schema
+
+It is now possible to use keys from the include schema in the `order` and `filter` params of the browse endpoint.
+
+```ts
+await api.tags.browse({
+  order: "count.post DESC",
+});
+```
+
+## Improved accuracy of Post schema
+- `published_at` is now nullable instead of nullish
+- `excerpt` is now nullable instead of nullish
+
+## Utility types
+
+Add utility types to get the Output Data part of a schema.
+
+### Extract Data Output `InferResponseDataShape`
+
+If you need to extract the `data` key of a successful Response (`status` is `success`), you can use `InferResponseDataShape`.
+
+```ts
+const res = await api.posts
+  .read({
+    slug: "my-blog-post",
+  })
+  .fields({ slug: true, html: true, tags: true })
+  .include({ tags: true })
+  .fetch();
+
+type SimplifiedBlogPost = InferResponseDataShape<typeof res>;
+```
+
+
+### Predict Fetcher Output `InferFetcherDataShape`
+
+Given a fetcher, it will predict the data shape type, before calling `fetch()` or `paginate()`
+
+```ts
+const exampleQuery = api.users.read({ id: "1" }).fields({ id: true, name: true, email: true });
+export type ExampleQueryOutput = InferFetcherDataShape<typeof exampleQuery>;
+```

--- a/.changeset/lovely-dragons-own.md
+++ b/.changeset/lovely-dragons-own.md
@@ -1,0 +1,5 @@
+---
+"@ts-ghost/core-api": minor
+---
+
+Order predicate can now contains nested fields like "count.posts" plus new utility Types.

--- a/packages/ts-ghost-core-api/src/index.ts
+++ b/packages/ts-ghost-core-api/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./schemas";
 export * from "./query-builder";
 export * from "./fetchers";
+export type * from "./utils";

--- a/packages/ts-ghost-core-api/src/query-builder/browse-params.ts
+++ b/packages/ts-ghost-core-api/src/query-builder/browse-params.ts
@@ -91,8 +91,12 @@ export const browseParamsSchema = z.object({
 });
 export type BrowseParamsSchema = z.infer<typeof browseParamsSchema>;
 
-export const parseBrowseParams = <P, Shape extends z.ZodRawShape>(args: P, schema: z.ZodObject<Shape>) => {
-  const keys = schema.keyof().options as string[];
+export const parseBrowseParams = <P, Shape extends z.ZodRawShape, IncludeShape extends z.ZodRawShape>(
+  args: P,
+  schema: z.ZodObject<Shape>,
+  includeSchema: z.ZodObject<IncludeShape>
+) => {
+  const keys = [...(schema.keyof().options as string[]), ...(includeSchema.keyof().options as string[])];
   const augmentedSchema = browseParamsSchema.merge(
     z.object({
       order: z

--- a/packages/ts-ghost-core-api/src/query-builder/browse-params.ts
+++ b/packages/ts-ghost-core-api/src/query-builder/browse-params.ts
@@ -94,9 +94,12 @@ export type BrowseParamsSchema = z.infer<typeof browseParamsSchema>;
 export const parseBrowseParams = <P, Shape extends z.ZodRawShape, IncludeShape extends z.ZodRawShape>(
   args: P,
   schema: z.ZodObject<Shape>,
-  includeSchema: z.ZodObject<IncludeShape>
+  includeSchema?: z.ZodObject<IncludeShape>
 ) => {
-  const keys = [...(schema.keyof().options as string[]), ...(includeSchema.keyof().options as string[])];
+  const keys = [
+    ...(schema.keyof().options as string[]),
+    ...((includeSchema && (includeSchema.keyof().options as string[])) || []),
+  ];
   const augmentedSchema = browseParamsSchema.merge(
     z.object({
       order: z

--- a/packages/ts-ghost-core-api/src/query-builder/query-builder.test.ts
+++ b/packages/ts-ghost-core-api/src/query-builder/query-builder.test.ts
@@ -23,7 +23,7 @@ describe("QueryBuilder", () => {
 
   const simplifiedIncludeSchema = z.object({
     count: z.literal(true).optional(),
-    "nested.count": z.literal(true).optional(),
+    "count.posts": z.literal(true).optional(),
   });
 
   const qb = new QueryBuilder(
@@ -83,7 +83,7 @@ describe("QueryBuilder", () => {
     test("order params should accept a string with IncludeSchema fields", () => {
       expect(
         qb.browse({
-          order: "nested.count desc",
+          order: "count.posts desc",
         })
       ).toBeInstanceOf(BrowseFetcher);
     });
@@ -134,7 +134,7 @@ describe("QueryBuilder", () => {
     test("filter params should accept a string with with IncludeSchema fields", () => {
       expect(
         qb.browse({
-          filter: "nested.count:test",
+          filter: "count.posts:test",
         })
       ).toBeInstanceOf(BrowseFetcher);
     });

--- a/packages/ts-ghost-core-api/src/query-builder/query-builder.test.ts
+++ b/packages/ts-ghost-core-api/src/query-builder/query-builder.test.ts
@@ -131,6 +131,14 @@ describe("QueryBuilder", () => {
       ).toBeInstanceOf(BrowseFetcher);
     });
 
+    test("filter params should accept a string with with IncludeSchema fields", () => {
+      expect(
+        qb.browse({
+          filter: "nested.count:test",
+        })
+      ).toBeInstanceOf(BrowseFetcher);
+    });
+
     test("filter params should not accept incorrect fields", () => {
       expect(() =>
         qb.browse({

--- a/packages/ts-ghost-core-api/src/query-builder/query-builder.test.ts
+++ b/packages/ts-ghost-core-api/src/query-builder/query-builder.test.ts
@@ -23,6 +23,7 @@ describe("QueryBuilder", () => {
 
   const simplifiedIncludeSchema = z.object({
     count: z.literal(true).optional(),
+    "nested.count": z.literal(true).optional(),
   });
 
   const qb = new QueryBuilder(
@@ -75,6 +76,14 @@ describe("QueryBuilder", () => {
       expect(
         qb.browse({
           order: "foo desc",
+        })
+      ).toBeInstanceOf(BrowseFetcher);
+    });
+
+    test("order params should accept a string with IncludeSchema fields", () => {
+      expect(
+        qb.browse({
+          order: "nested.count desc",
         })
       ).toBeInstanceOf(BrowseFetcher);
     });

--- a/packages/ts-ghost-core-api/src/query-builder/query-builder.ts
+++ b/packages/ts-ghost-core-api/src/query-builder/query-builder.ts
@@ -40,7 +40,7 @@ export class QueryBuilder<
       page?: number | string;
       filter?: FilterStr;
     }
-  >(options?: BrowseParams<P, Shape>) {
+  >(options?: BrowseParams<P, Shape & IncludeShape>) {
     return new BrowseFetcher(
       {
         schema: this.config.schema,
@@ -48,7 +48,7 @@ export class QueryBuilder<
         include: this.config.include,
       },
       {
-        browseParams: (options && parseBrowseParams(options, this.config.schema)) || undefined,
+        browseParams: (options && parseBrowseParams(options, this.config.schema, this.config.include)) || undefined,
       },
       this._api
     );

--- a/packages/ts-ghost-core-api/src/schemas/pages.ts
+++ b/packages/ts-ghost-core-api/src/schemas/pages.ts
@@ -39,7 +39,7 @@ export const basePagesSchema = z.object({
   reading_time: z.number().optional().default(0),
   created_at: z.string(),
   updated_at: z.string().nullish(),
-  published_at: z.string().nullish(),
+  published_at: z.string().nullable(),
   email_subject: z.string().nullish(),
   is_page: z.boolean().default(true),
 });

--- a/packages/ts-ghost-core-api/src/schemas/posts.ts
+++ b/packages/ts-ghost-core-api/src/schemas/posts.ts
@@ -34,11 +34,11 @@ export const basePostsSchema = z.object({
   primary_author: postsAuthorSchema.nullish(),
   primary_tag: baseTagsSchema.nullish(),
   url: z.string(),
-  excerpt: z.string().nullish(),
+  excerpt: z.string().nullable(),
   reading_time: z.number().optional().default(0),
   created_at: z.string(),
   updated_at: z.string().nullish(),
-  published_at: z.string().nullish(),
+  published_at: z.string().nullable(),
   email_subject: z.string().nullish(),
   is_page: z.boolean().default(false),
 });

--- a/packages/ts-ghost-core-api/src/utils.d.ts
+++ b/packages/ts-ghost-core-api/src/utils.d.ts
@@ -3,3 +3,6 @@ export declare type Mask<Obj> = {
 };
 
 export declare type InferGhostResponseData<T> = T extends { status: "success"; data: infer D } ? D : never;
+export declare type InferFetcherData<T extends { fetch: () => Promise<any> }> = InferGhostResponseData<
+  Awaited<ReturnType<T["fetch"]>>
+>;

--- a/packages/ts-ghost-core-api/src/utils.d.ts
+++ b/packages/ts-ghost-core-api/src/utils.d.ts
@@ -3,6 +3,7 @@ export declare type Mask<Obj> = {
 };
 
 export declare type InferGhostResponseData<T> = T extends { status: "success"; data: infer D } ? D : never;
+
 export declare type InferFetcherData<T extends { fetch: () => Promise<any> }> = InferGhostResponseData<
   Awaited<ReturnType<T["fetch"]>>
 >;

--- a/packages/ts-ghost-core-api/src/utils.d.ts
+++ b/packages/ts-ghost-core-api/src/utils.d.ts
@@ -1,3 +1,5 @@
 export declare type Mask<Obj> = {
   [k in keyof Obj]?: true;
 };
+
+export declare type InferGhostResponseData<T> = T extends { status: "success"; data: infer D } ? D : never;

--- a/packages/ts-ghost-core-api/src/utils.d.ts
+++ b/packages/ts-ghost-core-api/src/utils.d.ts
@@ -2,8 +2,8 @@ export declare type Mask<Obj> = {
   [k in keyof Obj]?: true;
 };
 
-export declare type InferGhostResponseData<T> = T extends { status: "success"; data: infer D } ? D : never;
+export declare type InferResponseDataShape<T> = T extends { status: "success"; data: infer D } ? D : never;
 
-export declare type InferFetcherData<T extends { fetch: () => Promise<any> }> = InferGhostResponseData<
+export declare type InferFetcherDataShape<T extends { fetch: () => Promise<any> }> = InferResponseDataShape<
   Awaited<ReturnType<T["fetch"]>>
 >;


### PR DESCRIPTION
## Browse params `order` and `filter` can now use keys from include schema

It is now possible to use keys from the include schema in the `order` and `filter` params of the browse endpoint.

```ts
await api.tags.browse({
  order: "count.post DESC",
});
```

## Improved accuracy of Post schema
- `published_at` is now nullable instead of nullish
- `excerpt` is now nullable instead of nullish

## Utility types

Add utility types to get the Output Data part of a schema.

### Extract Data Output `InferResponseDataShape`

If you need to extract the `data` key of a successful Response (`status` is `success`), you can use `InferResponseDataShape`.

```ts
const res = await api.posts
  .read({
    slug: "my-blog-post",
  })
  .fields({ slug: true, html: true, tags: true })
  .include({ tags: true })
  .fetch();

type SimplifiedBlogPost = InferResponseDataShape<typeof res>;
```


### Predict Fetcher Output `InferFetcherDataShape`

Given a fetcher, it will predict the data shape type, before calling `fetch()` or `paginate()`

```ts
const exampleQuery = api.users.read({ id: "1" }).fields({ id: true, name: true, email: true });
export type ExampleQueryOutput = InferFetcherDataShape<typeof exampleQuery>;
```