### PR TITLE
update TS definition of API Version and Zod Schema

### DIFF
--- a/.changeset/violet-pets-doubt.md
+++ b/.changeset/violet-pets-doubt.md
@@ -1,0 +1,12 @@
+---
+"@ts-ghost/admin-api": patch
+"@ts-ghost/content-api": patch
+"@ts-ghost/core-api": patch
+"@ts-ghost/ghost-blog-buster": patch
+---
+
+## Changes
+
+- Update the TS definition of `APIVersion` to accept only `v5.x` for now.
+- Updated the corresponding zod schema to have regex validation.
+- Updated documentation to give info about the supported versions

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,57 @@
+# This template is a direct copy of the @trpc bug report template
+# See here: https://github.com/trpc/trpc/blob/main/.github/ISSUE_TEMPLATE/1.bug_report.yml
+
+name: 🐞 Bug Report
+description: Create a bug report for the core packages
+title: "bug: "
+labels: ["🐛 bug: unconfirmed"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report! Please fill out this form as completely as possible.
+        Note that the more precise you are, the quicker we will be able to investigate the bug.
+  - type: textarea
+    attributes:
+      label: Provide environment information
+      description: |
+        Run this command in your project root and paste the results:
+
+        ```terminal
+        npx envinfo --system --binaries --browsers --npmPackages "typescript,@ts-ghost/content-api,@ts-ghost/admin-api,@ts-ghost/core-api,@ts-ghost/ghost-blog-buster"
+        ```
+      placeholder: |
+        ``` 
+        <Paste result here> 
+        ```
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Describe the bug
+      description: Please describe the bug as clear and concise as possible, as well as the behavior you were expecting whilst encountering the bug.
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Target Ghost Blog version
+      description: Please provide the version of the Ghost Blog you are interacting with, knowing that mosts tools here are tested against Ghost v5 minimum.
+      placeholder: "v5.0"
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: To reproduce
+      description: Describe how to reproduce your bug. Can be either code or a link to a reproduction repo, Stackblitz etc.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional information
+      description: Add any other information related to the bug here.
+  - type: checkboxes
+    attributes:
+      label: 👨‍👧‍👦 Contributing
+      description: We love contributors in any shape or form. Would you be willing to implement a fix?
+      options:
+        - label: 🙋‍♂️ Yes, I'd be down to file a PR fixing this bug!

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,42 @@
+# This template is a direct copy of the @trpc feature request template
+# See here: https://github.com/trpc/trpc/blob/main/.github/ISSUE_TEMPLATE/2.feature_request.yml
+
+name: 🛠 Feature Request
+description: Create a feature request for the core packages
+title: "feat: "
+labels: ["✨ enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to file a feature request. Please fill out this form as completely as possible.
+  - type: textarea
+    attributes:
+      label: Describe the feature you'd like to request
+      description: Please describe the feature as clear and concise as possible. Remember to add context as to why you believe this feature is needed.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Describe the solution you'd like to see
+      description: Please describe the solution you would like to see. Adding example usage is a good way to provide context.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Describe alternate solutions
+      description: |
+        Please describe alternate solutions you have considered. What makes your suggested feature better?
+        If you currently have a workaround to get a similar experience, add that here.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional information
+      description: Add any other information related to the feature here. If your feature request is related to any issues or discussions, link them here.
+  - type: checkboxes
+    attributes:
+      label: 👨‍👧‍👦 Contributing
+      description: We love contributors in any shape or form. Would you be willing to implement this feature?
+      options:
+        - label: 🙋‍♂️ Yes, I'd be down to file a PR implementing this feature!

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+Closes #
+
+## Changes
+
+What changes are made in this PR? Is it a feature or a bug fix?
+
+## Checklist
+
+- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/PhilDL/ts-ghost/blob/main/CONTRIBUTING.md).
+- [ ] If necessary, I have added documentation related to the changes made.
+- [ ] I have added or updated the tests related to the changes made.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,94 @@
+# Contributing
+
+Thank you for thinking about contributing! `ts-ghost` is a small project that wants to grow and improve. We are always looking for new contributors to help us make it better. This document will help you get started.
+## Development workflow
+
+We use [pnpm](https://pnpm.io) as our package manager, so make sure to [install](https://pnpm.io/installation) it first.
+
+```bash
+git clone git@github.com:PhilDL/ts-ghost.git
+cd ts-ghost
+pnpm i
+pnpm build
+```
+
+### Commands
+
+This is a monorepo powered by turborepo, so you can run commands in the root directory and it will run the command in all packages.
+
+```bash
+# From the project root directory
+pnpm build
+```
+
+This will build all the packages.
+
+### Testing
+
+During your developement you may want to keep the tests running in watch mode.
+
+```bash
+# From the project root directory
+pnpm test:watch
+# If you want to test a specific package
+pnpm test:watch --filter @ts-ghost/core-api
+```
+
+### Integration Testing against real Ghost Instance
+
+Integration testing is done in `@ts-ghost/content-api` and `@ts-ghost/admin-api` packages, against a test instance of Ghost called [`astro-starter-ghost`](https://astro-starter.digitalpress.blog). These tests are 
+made to be run in CI with the hidden `.env` variables containing admin and content API key set for that specific ghost instance.
+
+Trying to run these tests locally without having the correct `.env` values will certainly fail.
+
+```bash
+# From the project root directory
+# This will fail as it is expecting specific values from a specific Ghost Instance
+pnpm test:integration:watch
+```
+
+### Linting, typecheck
+
+```bash
+# Eslint
+pnpm lint
+# Typecheck typescript
+pnpm typecheck
+```
+
+### Running `validate` to lint, typecheck and tests
+
+```bash
+# From the project root directory
+pnpm validate
+```
+
+### Documentation
+
+```bash
+cd www/ && pnpm dev
+```
+
+## Project overview
+
+This project is a monorepo of packages with well-defined purposes. It is composed of an app "ghost-blog-buster", and several API Client packages.
+
+- The `ghost-blog-buster` CLI is located in the `apps` directory.
+- Client API Packages are located in the `packages` directory.
+
+### `@ts-ghost/ghost-blog-buster`
+
+TODO: write description and help for this package.
+
+### `@ts-ghost/content-api`
+
+TODO: write description and help for this package.
+
+
+### `@ts-ghost/admin-api`
+
+TODO: write description and help for this package.
+
+### `@ts-ghost/core-api`
+
+TODO: write description and help for this package.

--- a/apps/ghost-blog-buster/README.md
+++ b/apps/ghost-blog-buster/README.md
@@ -31,6 +31,10 @@ Ghost Blog Buster is an interactive CLI allowing you to interact with your Ghost
 - ⚙️ Display or export to JSON your **Tags**, **Tiers**, **Authors**, **Members** (Admin API only)
 - 📶 Connect / Disconnect from the Blog
 
+## Compatible Ghost versions.
+This tool was developped and tested mostly for Ghost versions 5.x.
+- Ghost 5^
+
 ## Built With
 
 - [TypeScript](https://github.com/microsoft/TypeScript)

--- a/packages/ts-ghost-admin-api/README.md
+++ b/packages/ts-ghost-admin-api/README.md
@@ -44,6 +44,10 @@ pnpm i @ts-ghost/admin-api
 
 This is a quick example of how to use the library.
 
+### Compatible Ghost versions.
+This client is only compatible with Ghost versions 5.x for now.
+- Ghost 5^
+
 ### Browse multiple posts 
 
 ```typescript

--- a/packages/ts-ghost-admin-api/src/admin-api.ts
+++ b/packages/ts-ghost-admin-api/src/admin-api.ts
@@ -4,23 +4,13 @@ import { adminMembersSchema } from "./schemas/members";
 import { adminTiersSchema } from "./schemas";
 import { adminUsersSchema } from "./schemas/users";
 import { baseNewsletterSchema, baseOffersSchema, baseTagsSchema } from "@ts-ghost/core-api";
-import {
-  adminAPICredentialsSchema,
-  QueryBuilder,
-  AdminAPIVersions,
-  baseSiteSchema,
-  BasicFetcher,
-} from "@ts-ghost/core-api";
+import { adminAPICredentialsSchema, QueryBuilder, APIVersions, baseSiteSchema, BasicFetcher } from "@ts-ghost/core-api";
 import { z } from "zod";
 
-export type { AdminAPICredentials, AdminAPIVersions } from "@ts-ghost/core-api";
+export type { AdminAPICredentials, APIVersions } from "@ts-ghost/core-api";
 
-export class TSGhostAdminAPI {
-  constructor(
-    protected readonly url: string,
-    protected readonly key: string,
-    protected readonly version: AdminAPIVersions
-  ) {}
+export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
+  constructor(protected readonly url: string, protected readonly key: string, protected readonly version: Version) {}
   get posts() {
     const api = adminAPICredentialsSchema.parse({
       resource: "posts",
@@ -31,7 +21,7 @@ export class TSGhostAdminAPI {
     }) as {
       resource: "posts";
       key: string;
-      version: AdminAPIVersions;
+      version: APIVersions;
       url: string;
       endpoint: "admin";
     };
@@ -59,7 +49,7 @@ export class TSGhostAdminAPI {
     }) as {
       resource: "pages";
       key: string;
-      version: AdminAPIVersions;
+      version: APIVersions;
       url: string;
       endpoint: "admin";
     };
@@ -87,7 +77,7 @@ export class TSGhostAdminAPI {
     }) as {
       resource: "members";
       key: string;
-      version: AdminAPIVersions;
+      version: APIVersions;
       url: string;
       endpoint: "admin";
     };
@@ -112,7 +102,7 @@ export class TSGhostAdminAPI {
     }) as {
       resource: "tiers";
       key: string;
-      version: AdminAPIVersions;
+      version: APIVersions;
       url: string;
       endpoint: "admin";
     };
@@ -141,7 +131,7 @@ export class TSGhostAdminAPI {
     }) as {
       resource: "newsletters";
       key: string;
-      version: AdminAPIVersions;
+      version: APIVersions;
       url: string;
       endpoint: "admin";
     };
@@ -166,7 +156,7 @@ export class TSGhostAdminAPI {
     }) as {
       resource: "offers";
       key: string;
-      version: AdminAPIVersions;
+      version: APIVersions;
       url: string;
       endpoint: "admin";
     };
@@ -191,7 +181,7 @@ export class TSGhostAdminAPI {
     }) as {
       resource: "tags";
       key: string;
-      version: AdminAPIVersions;
+      version: APIVersions;
       url: string;
       endpoint: "admin";
     };
@@ -218,7 +208,7 @@ export class TSGhostAdminAPI {
     }) as {
       resource: "users";
       key: string;
-      version: AdminAPIVersions;
+      version: APIVersions;
       url: string;
       endpoint: "admin";
     };
@@ -243,7 +233,7 @@ export class TSGhostAdminAPI {
     }) as {
       resource: "site";
       key: string;
-      version: AdminAPIVersions;
+      version: APIVersions;
       url: string;
       endpoint: "admin";
     };

--- a/packages/ts-ghost-content-api/README.md
+++ b/packages/ts-ghost-content-api/README.md
@@ -33,6 +33,11 @@ pnpm i @ts-ghost/content-api
 
 This is a quick example of how to use the library.
 
+### Compatible Ghost versions.
+This client is only compatible with Ghost versions 5.x for now.
+- Ghost 5^
+
+
 ### Browse multiple posts 
 
 ```typescript

--- a/packages/ts-ghost-content-api/src/content-api.ts
+++ b/packages/ts-ghost-content-api/src/content-api.ts
@@ -3,11 +3,11 @@ import { tagsSchema, tagsIncludeSchema } from "./tags/schemas";
 import { pagesSchema, pagesIncludeSchema } from "./pages/schemas";
 import { postsSchema, postsIncludeSchema } from "./posts/schemas";
 import { tiersSchema, tiersIncludeSchema } from "./tiers/schemas";
-import { contentAPICredentialsSchema, QueryBuilder, ContentAPIVersions } from "@ts-ghost/core-api";
+import { contentAPICredentialsSchema, QueryBuilder, APIVersions, type TAPIVersion } from "@ts-ghost/core-api";
 import { BasicFetcher } from "@ts-ghost/core-api";
 import { settingsSchema } from "./settings/schemas";
 
-export type { ContentAPICredentials, ContentAPIVersions } from "@ts-ghost/core-api";
+export type { ContentAPICredentials, APIVersions } from "@ts-ghost/core-api";
 
 export enum BrowseEndpointType {
   authors = "authors",
@@ -18,12 +18,8 @@ export enum BrowseEndpointType {
   settings = "settings",
 }
 
-export class TSGhostContentAPI {
-  constructor(
-    protected readonly url: string,
-    protected readonly key: string,
-    protected readonly version: ContentAPIVersions
-  ) {}
+export class TSGhostContentAPI<Version extends `v5.${string}` = any> {
+  constructor(protected readonly url: string, protected readonly key: string, protected readonly version: Version) {}
 
   get authors() {
     const api = contentAPICredentialsSchema.parse({
@@ -35,7 +31,7 @@ export class TSGhostContentAPI {
     }) as {
       resource: "authors";
       key: string;
-      version: ContentAPIVersions;
+      version: APIVersions;
       url: string;
       endpoint: "content";
     };
@@ -58,7 +54,7 @@ export class TSGhostContentAPI {
     }) as {
       resource: "tiers";
       key: string;
-      version: ContentAPIVersions;
+      version: APIVersions;
       url: string;
       endpoint: "content";
     };
@@ -74,7 +70,7 @@ export class TSGhostContentAPI {
     }) as {
       resource: "posts";
       key: string;
-      version: ContentAPIVersions;
+      version: APIVersions;
       url: string;
       endpoint: "content";
     };
@@ -97,7 +93,7 @@ export class TSGhostContentAPI {
     }) as {
       resource: "pages";
       key: string;
-      version: ContentAPIVersions;
+      version: APIVersions;
       url: string;
       endpoint: "content";
     };
@@ -120,7 +116,7 @@ export class TSGhostContentAPI {
     }) as {
       resource: "tags";
       key: string;
-      version: ContentAPIVersions;
+      version: APIVersions;
       url: string;
       endpoint: "content";
     };
@@ -137,7 +133,7 @@ export class TSGhostContentAPI {
     }) as {
       resource: "settings";
       key: string;
-      version: ContentAPIVersions;
+      version: APIVersions;
       url: string;
       endpoint: "content";
     };

--- a/packages/ts-ghost-core-api/README.md
+++ b/packages/ts-ghost-core-api/README.md
@@ -27,6 +27,11 @@
 pnpm i @ts-ghost/core-api
 ```
 
+### Compatible Ghost versions.
+This client is only compatible with Ghost versions 5.x for now.
+- Ghost 5^
+
+
 ## QueryBuilder
 
 A QueryBuilder is a class that helps you build a query based on a a combinations of ZodSchema. This QueryBuilder exposes 2 methods `read` to fetch a single record and `browse` to fetch multiple records. `read` and `browse` gives you back the appropriate `Fetcher` instance that will handle the actual request to the API with the correct parameters.

--- a/packages/ts-ghost-core-api/src/schemas/shared.ts
+++ b/packages/ts-ghost-core-api/src/schemas/shared.ts
@@ -90,9 +90,12 @@ export const ghostVisibilitySchema = z.union([
   z.literal("paid"),
 ]);
 
-export const apiVersionsSchema = z.enum(["v5.0", "v2", "v3", "v4", "canary"]).default("v5.0");
-export type ContentAPIVersions = z.infer<typeof apiVersionsSchema>;
-export type AdminAPIVersions = z.infer<typeof apiVersionsSchema>;
+export const apiVersionsSchema = z
+  .string()
+  .regex(/^v5\.\d+/)
+  .default("v5.0");
+export type TAPIVersion<V> = V extends "v5.0" | `v5.${infer Minor}` ? `v5.${Minor}` : never;
+export type APIVersions = z.infer<typeof apiVersionsSchema>;
 
 export const contentAPICredentialsSchema = z.discriminatedUnion("resource", [
   z.object({
@@ -155,7 +158,7 @@ export type APICredentials = {
     | "users"
     | "newsletters";
   key: string;
-  version: ContentAPIVersions;
+  version: APIVersions;
   url: string;
   endpoint: "admin" | "content";
 };


### PR DESCRIPTION
## Changes

- Update the TS definition of `APIVersion` to accept only `v5.x` for now.
- Updated the corresponding zod schema to have regex validation.
- Updated documentation to give info about the supported versions

## Checklist

- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.