### PR TITLE
add options arg to `fetch` functions

### DIFF
--- a/.changeset/witty-balloons-prove.md
+++ b/.changeset/witty-balloons-prove.md
@@ -1,0 +1,7 @@
+---
+"@ts-ghost/content-api": patch
+"@ts-ghost/admin-api": patch
+"@ts-ghost/core-api": patch
+---
+
+Allow options to be passed to fetch

--- a/packages/ts-ghost-admin-api/README.md
+++ b/packages/ts-ghost-admin-api/README.md
@@ -314,6 +314,15 @@ const result: {
 
 Here you can use the `next` property to get the next page fetcher if it is defined.
 
+### `fetch` options
+
+You can pass an optional `options` object to the `fetch` and `paginate` method. The `options` object is the standard `RequestInit` object from the `fetch` API.
+
+```typescript
+let result = await api.posts.read({ slug: "typescript-is-cool" }).fetch({ cache: "no-store" });
+```
+*This may be useful if you use NextJS augmented `fetch`!*
+
 
 ## Commons recipes
 

--- a/packages/ts-ghost-content-api/README.md
+++ b/packages/ts-ghost-content-api/README.md
@@ -394,6 +394,15 @@ const result = await api.posts
   .fetch();
 ```
 
+### `fetch` options
+
+You can pass an optional `options` object to the `fetch` and `paginate` method. The `options` object is the standard `RequestInit` object from the `fetch` API.
+
+```typescript
+let result = await api.posts.read({ slug: "typescript-is-cool" }).fetch({ cache: "no-store" });
+```
+*This may be useful if you use NextJS augmented `fetch`!*
+
 ## Roadmap
 
 - [ ] Write more tests

--- a/packages/ts-ghost-core-api/README.md
+++ b/packages/ts-ghost-core-api/README.md
@@ -391,6 +391,15 @@ let result = await bf.fields({
 }).fetch();
 ```
 
+### `fetch` options
+
+You can pass an optional `options` object to the `fetch` and `paginate` method. The `options` object is the standard `RequestInit` object from the `fetch` API.
+
+```typescript
+let result = await api.posts.read({ slug: "typescript-is-cool" }).fetch({ cache: "no-store" });
+```
+*This may be useful if you use NextJS augmented `fetch`!*
+
 ## Roadmap
 
 - Handling POST, PUT and DELETE requests.

--- a/packages/ts-ghost-core-api/src/fetchers/basic-fetcher.ts
+++ b/packages/ts-ghost-core-api/src/fetchers/basic-fetcher.ts
@@ -43,7 +43,7 @@ export class BasicFetcher<OutputShape extends ZodRawShape = any, Api extends API
     this._URL = url;
   }
 
-  public async fetch() {
+  public async fetch(options?: RequestInit) {
     const res = z.discriminatedUnion("status", [
       z.object({
         status: z.literal("success"),
@@ -59,7 +59,7 @@ export class BasicFetcher<OutputShape extends ZodRawShape = any, Api extends API
         ),
       }),
     ]);
-    const result = await _fetch(this._URL, this._api);
+    const result = await _fetch(this._URL, this._api, options);
     let data: any = {};
     if (result.errors) {
       data.status = "error";

--- a/packages/ts-ghost-core-api/src/fetchers/browse-fetcher.ts
+++ b/packages/ts-ghost-core-api/src/fetchers/browse-fetcher.ts
@@ -195,9 +195,9 @@ export class BrowseFetcher<
     ]);
   }
 
-  public async fetch() {
+  public async fetch(options?: RequestInit) {
     const resultSchema = this._getResultSchema();
-    const result = await _fetch(this._URL, this._api);
+    const result = await _fetch(this._URL, this._api, options);
     let data: any = {};
     if (result.errors) {
       data.status = "error";
@@ -221,7 +221,7 @@ export class BrowseFetcher<
     return resultSchema.parse(data);
   }
 
-  public async paginate() {
+  public async paginate(options?: RequestInit) {
     if (!this._params.browseParams?.page) {
       this._params.browseParams = {
         ...this._params.browseParams,
@@ -231,7 +231,7 @@ export class BrowseFetcher<
     }
 
     const resultSchema = this._getResultSchema();
-    const result = await _fetch(this._URL, this._api);
+    const result = await _fetch(this._URL, this._api, options);
     let data: any = {};
     if (result.errors) {
       data.status = "error";

--- a/packages/ts-ghost-core-api/src/fetchers/helpers.ts
+++ b/packages/ts-ghost-core-api/src/fetchers/helpers.ts
@@ -25,13 +25,14 @@ export async function _genHeaders(api: APICredentials) {
   return headers;
 }
 
-export async function _fetch(URL: URL | undefined, api: APICredentials) {
+export async function _fetch(URL: URL | undefined, api: APICredentials, options?: RequestInit) {
   if (URL === undefined) throw new Error("URL is undefined");
   let result = undefined;
   const headers = await _genHeaders(api);
   try {
     result = await (
       await fetch(URL.toString(), {
+        ...options,
         headers,
       })
     ).json();

--- a/packages/ts-ghost-core-api/src/fetchers/read-fetcher.ts
+++ b/packages/ts-ghost-core-api/src/fetchers/read-fetcher.ts
@@ -161,7 +161,7 @@ export class ReadFetcher<
     this._URL = url;
   }
 
-  public async fetch() {
+  public async fetch(options?: RequestInit) {
     const res = z.discriminatedUnion("status", [
       z.object({
         status: z.literal("success"),
@@ -177,7 +177,7 @@ export class ReadFetcher<
         ),
       }),
     ]);
-    const result = await _fetch(this._URL, this._api);
+    const result = await _fetch(this._URL, this._api, options);
     let data: any = {};
     if (result.errors) {
       data.status = "error";


### PR DESCRIPTION
## Changes

Allow `options: RequestInit` arg to `fetch` and `paginate` method to give more options and prepare for NextJS 13

## Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/PhilDL/ts-ghost/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.