### PR TITLE
admin-api: add possibility to include tiers to posts or pages

### DIFF
--- a/.changeset/clean-kangaroos-compare.md
+++ b/.changeset/clean-kangaroos-compare.md
@@ -1,0 +1,16 @@
+---
+"@ts-ghost/admin-api": minor
+---
+
+## Changes `admin-api`
+
+The "include" schema of the `posts` and `pages` have been updated to allow including `tiers` to the response.
+
+```ts
+const res = await api.posts
+  .read({ slug: "create-field-widget-in-owl-odoo-16" })
+  .include({ tags: true, authors: true, tiers: true })
+  //                                     ^ Include tiers
+  .formats({ html: true })
+  .fetch();
+```

--- a/packages/ts-ghost-admin-api/src/admin-api.ts
+++ b/packages/ts-ghost-admin-api/src/admin-api.ts
@@ -47,6 +47,7 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
     const postsIncludeSchema = z.object({
       authors: z.literal(true).optional(),
       tags: z.literal(true).optional(),
+      tiers: z.literal(true).optional(),
     });
     return new APIComposer(
       {
@@ -77,6 +78,7 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
     const pagesIncludeSchema = z.object({
       authors: z.literal(true).optional(),
       tags: z.literal(true).optional(),
+      tiers: z.literal(true).optional(),
     });
     return new APIComposer(
       {

--- a/packages/ts-ghost-admin-api/src/schemas/posts.ts
+++ b/packages/ts-ghost-admin-api/src/schemas/posts.ts
@@ -12,7 +12,7 @@ export const adminPostsSchema = basePostsSchema.merge(
     status: z.union([z.literal("draft"), z.literal("published"), z.literal("scheduled")]),
     email_segment: z.string().nullish(),
     frontmatter: z.string().nullish(),
-    tiers: z.array(adminTiersSchema).nullish(),
+    tiers: z.array(adminTiersSchema).optional(),
     email: baseEmailSchema.nullish(),
     newsletter: baseNewsletterSchema.nullish(),
     count: z


### PR DESCRIPTION
## Changes `admin-api`

The "include" schema of the `posts` and `pages` have been updated to allow including `tiers` to the response.

## Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/PhilDL/ts-ghost/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
