### PR TITLE
add limit possibility "all" and better "filter" typing to allow "in" array of values

### DIFF
--- a/.changeset/twelve-bananas-vanish.md
+++ b/.changeset/twelve-bananas-vanish.md
@@ -1,0 +1,7 @@
+---
+"@ts-ghost/content-api": patch
+"@ts-ghost/admin-api": patch
+"@ts-ghost/core-api": patch
+---
+
+Add possibility to browse with limit "all"

--- a/docs/src/app/docs/admin-api/browse/page.mdx
+++ b/docs/src/app/docs/admin-api/browse/page.mdx
@@ -33,9 +33,10 @@ These browse params are then parsed through a `Zod` Schema that will validate al
 
 Lets you query a specific page of results. The default value is `1` and pagination starts at `1`.
 
-### limit `number`
+### limit `number` | `"all"`
 
 Lets you limit the number of results per page. The default value is `15` and the maximum value is `15` (limitation of the Ghost API).
+You can also pass the literal string `"all"` to get all the results.
 
 ### filter `string`
 
@@ -149,7 +150,7 @@ const result: {
     meta: {
         pagination: {
             pages: number;
-            limit: number;
+            limit: number | "all";
             page: number;
             total: number;
             prev: number | null;

--- a/docs/src/app/docs/content-api/browse/page.mdx
+++ b/docs/src/app/docs/content-api/browse/page.mdx
@@ -25,9 +25,10 @@ These browse params are then parsed through a `Zod` Schema that will validate al
 
 Lets you query a specific page of results. The default value is `1` and pagination starts at `1`.
 
-### limit `number`
+### limit `number` | `"all"`
 
 Lets you limit the number of results per page. The default value is `15` and the maximum value is `15` (limitation of the Ghost API).
+You can also pass the literal string `"all"` to get all the results.
 
 ### filter `string`
 
@@ -114,7 +115,7 @@ const result: {
     meta: {
         pagination: {
             pages: number;
-            limit: number;
+            limit: number | "all";
             page: number;
             total: number;
             prev: number | null;
@@ -141,7 +142,7 @@ const result: {
     meta: {
         pagination: {
             pages: number;
-            limit: number;
+            limit: number | "all";
             page: number;
             total: number;
             prev: number | null;

--- a/packages/ts-ghost-admin-api/README.md
+++ b/packages/ts-ghost-admin-api/README.md
@@ -41,6 +41,8 @@ This client is only compatible with Ghost versions 5.x for now.
     polyfill and if you run Node 16, you'll need to run with the
     `--experimental-fetch` flag enabled.
 - TypeScript 5+, the lib make usage of const in generics and other TS5+ features.
+
+<ContentNavigation next={{ title: "Quickstart", href: "/docs/admin-api/quickstart" }} />
 # Quickstart
 
 These are the basic steps to follow to interact with the Ghost Content API in your TypeScript project.
@@ -130,6 +132,11 @@ export async function getBlogPosts() {
 ```
 
 
+
+<ContentNavigation
+  previous={{ title: "Introduction", href: "/docs/admin-api" }}
+  next={{ title: "Overview", href: "/docs/admin-api/overview" }}
+/>
 # Overview
 
 Here you will have an overview of the philosophy of the library and a common workflow for your queries.
@@ -318,6 +325,11 @@ if (!postDelete.success) {
   throw new Error("Failed to delete post");
 }
 ```
+
+<ContentNavigation
+  previous={{ title: "Quickstart", href: "/docs/admin-api/quickstart" }}
+  next={{ title: "Browse", href: "/docs/admin-api/browse" }}
+/>
 # Browse
 
 The `browse` method is used to get a list of items from a Ghost Admin API resource, it is the equivalent of the `GET /members` endpoint. You have access to different options to paginate, limit, filter and order your results.
@@ -353,9 +365,10 @@ These browse params are then parsed through a `Zod` Schema that will validate al
 
 Lets you query a specific page of results. The default value is `1` and pagination starts at `1`.
 
-### limit `number`
+### limit `number` | `"all"`
 
 Lets you limit the number of results per page. The default value is `15` and the maximum value is `15` (limitation of the Ghost API).
+You can also pass the literal string `"all"` to get all the results.
 
 ### filter `string`
 
@@ -469,7 +482,7 @@ const result: {
     meta: {
         pagination: {
             pages: number;
-            limit: number;
+            limit: number | "all";
             page: number;
             total: number;
             prev: number | null;
@@ -488,6 +501,11 @@ const result: {
 ```
 
 Here you can use the `next` property to get the next page fetcher if it is defined.
+
+<ContentNavigation
+  previous={{ title: "Overview", href: "/docs/admin-api/overview" }}
+  next={{ title: "Read", href: "/docs/admin-api/read" }}
+/>
 # Read
 
 The `read` method is used to one item from a Ghost Admin API resource, it is the equivalent of the `GET /posts/slug/this-is-a-slug` endpoint. You have to give it an identity field to fetch the resource.
@@ -574,6 +592,11 @@ const result: {
     }[];
 }
 ```
+
+<ContentNavigation
+  previous={{ title: "Browse", href: "/docs/admin-api/browse" }}
+  next={{ title: "Output Modfiers", href: "/docs/admin-api/output-modifiers" }}
+/>
 # Output modifiers
 
 Output modifiers are available for the `read` and `browse` methods. They let you change the output of the result to have only your selected fields, include some additionnal data that the Ghost API doesn't give you by default or get the content in different formats.
@@ -727,6 +750,11 @@ let query = await api.posts
   })
   .fetch({ next: { revalidate: 10 } }); // NextJS revalidate this data every 10 seconds at most
 ```
+
+<ContentNavigation
+  previous={{ title: "Output Modfiers", href: "/docs/admin-api/output-modifiers" }}
+  next={{ title: "Add", href: "/docs/admin-api/add" }}
+/>
 # Add
 
 Add lets you create a new record of a given resource. The `add` method is available on the resources that support it. (For example on the `users` resource don't have access to any mutation methods).
@@ -780,7 +808,7 @@ The result will be parsed and typed with the `output` schema and represent the n
 // return from the `add` method
 const result: {
     success: true;
-    data: z.infer<typeof simplifiedSchema>; // parsed by the Zod Schema given in the config
+    data: Member; // parsed by the Zod Schema given in the config
 } | {
     success: false;
     errors: {
@@ -789,6 +817,11 @@ const result: {
     }[];
 }
 ```
+
+<ContentNavigation
+  previous={{ title: "Fetching", href: "/docs/admin-api/fetching" }}
+  next={{ title: "Edit", href: "/docs/admin-api/edit" }}
+/>
 # Edit
 
 Edit lets you edit an existing record of a given resource by inputing the resource `id` and the new data. The `edit` method is available on the resources that support it. (For example on the `users` resource don't have access to any mutation methods).
@@ -834,6 +867,11 @@ const result: {
     }[];
 }
 ```
+
+<ContentNavigation
+  previous={{ title: "Add", href: "/docs/admin-api/add" }}
+  next={{ title: "Delete", href: "/docs/admin-api/delete" }}
+/>
 # Delete
 
 Delete is an async function that requires the `id` of the record to delete. _Some resources don't support deletion, but instead give you accessed to a soft delete through the `status` field in the `edit` method._
@@ -872,6 +910,11 @@ const result: {
     }[];
 }
 ```
+
+<ContentNavigation
+  previous={{ title: "Add", href: "/docs/admin-api/add" }}
+  next={{ title: "Members & Subscriptions", href: "/docs/admin-api/members-recipes" }}
+/>
 # Members & Subscriptions recipes
 
 The advantage of using the admin API is that you can create, edit and delete members. This is not possible with the content API.
@@ -942,6 +985,11 @@ export const getMemberActiveSubscriptions = async (memberId: string) => {
   return subscriptions.data.subscriptions.filter((sub) => sub.status === "active");
 };
 ```
+
+<ContentNavigation
+  previous={{ title: "Delete", href: "/docs/admin-api/delete" }}
+  next={{ title: "UPDATE_COLLISION error", href: "/docs/admin-api/posts-update-collision-error" }}
+/>
 # How to avoid post / page "UPDATE_COLLISION" Error
 
 When updating `posts` or `page` with the Admin API, Ghost expects you to send the `updated_at` field with the **current updated_at value** of that Post or Page.
@@ -973,6 +1021,11 @@ const postEditResult = await api.posts.edit(post.id, {
   updated_at: new Date(post.updated_at || ""),
 });
 ```
+
+<ContentNavigation
+  previous={{ title: "Members & Subscriptions", href: "/docs/admin-api/members-recipes" }}
+  next={{ title: "Common Recipes", href: "/docs/admin-api/common-recipes" }}
+/>
 # Commons recipes
 
 Here is a growing collections of things you can achieve with the `@ts-ghost/admin-api`.
@@ -1023,6 +1076,11 @@ if (result.success) {
   //     ^? type Settings {title: string; description: string; ...
 }
 ```
+
+<ContentNavigation
+  previous={{ title: "UPDATE_COLLISION error", href: "/docs/admin-api/posts-update-collision-error" }}
+  next={{ title: "Remix", href: "/docs/admin-api/remix" }}
+/>
 # Remix example
 
 Here is an example using the `@ts-ghost/admin-api` in a Remix loader:
@@ -1089,6 +1147,11 @@ export default function Index() {
 ```
 
 </Steps>
+
+<ContentNavigation
+  next={{ title: "NextJS", href: "/docs/admin-api/nextjs" }}
+  previous={{ title: "Common recipes", href: "/docs/admin-api/common-recipes" }}
+/>
 # NextJS
 
 This is an example for NextJS 13 using the `@ts-ghost/admin-api` with the app Router where we fetch the list of posts and the site settings to display them on the `/blog` of our site.
@@ -1160,6 +1223,11 @@ export default async function HomePage() {
 ```
 
 </Steps>
+
+<ContentNavigation
+  previous={{ title: "Remix", href: "/docs/admin-api/remix" }}
+  next={{ title: "TypeScript recipes", href: "/docs/admin-api/advanced-typescript" }}
+/>
 # TypeScript recipes
 
 Sometimes TypeScript will get in your way, especially with the string-based type-checking on browse parameters. In this section we will show you some tips and tricks to get around those problems, and present you some utilities.
@@ -1213,6 +1281,8 @@ const uncontrolledOrderInput = async (formData: FormData) => {
     .fetch();
 };
 ```
+
+<ContentNavigation previous={{ title: "NextJS", href: "/docs/admin-api/nextjs" }} />
 
 
 ## Roadmap

--- a/packages/ts-ghost-content-api/README.md
+++ b/packages/ts-ghost-content-api/README.md
@@ -39,6 +39,8 @@ This client is only compatible with Ghost versions 5.x for now.
     polyfill and if you run Node 16, you'll need to run with the
     `--experimental-fetch` flag enabled.
 - TypeScript 5+, the lib make usage of const in generics and other TS5+ features.
+
+<ContentNavigation next={{ title: "Quickstart", href: "/docs/content-api/quickstart" }} />
 # Quickstart
 
 These are the basic steps to follow to interact with the Ghost Content API in your TypeScript project.
@@ -108,6 +110,11 @@ export async function getBlogPosts() {
 ```
 
 
+
+<ContentNavigation
+  previous={{ title: "Introduction", href: "/docs/content-api" }}
+  next={{ title: "Overview", href: "/docs/content-api/overview" }}
+/>
 # Overview
 
 Here you will have an overview of the philosophy of the library and a common workflow for your queries.
@@ -219,6 +226,11 @@ const result: {
     }[];
 }
 ```
+
+<ContentNavigation
+  previous={{ title: "Quickstart", href: "/docs/content-api/quickstart" }}
+  next={{ title: "Browse", href: "/docs/content-api/browse" }}
+/>
 # Browse
 
 The `browse` method is used to get a list of items from a Ghost Content API resource, it is the equivalent of the `GET /posts` endpoint. You have access to different options to paginate, limit, filter and order your results.
@@ -246,9 +258,10 @@ These browse params are then parsed through a `Zod` Schema that will validate al
 
 Lets you query a specific page of results. The default value is `1` and pagination starts at `1`.
 
-### limit `number`
+### limit `number` | `"all"`
 
 Lets you limit the number of results per page. The default value is `15` and the maximum value is `15` (limitation of the Ghost API).
+You can also pass the literal string `"all"` to get all the results.
 
 ### filter `string`
 
@@ -335,7 +348,7 @@ const result: {
     meta: {
         pagination: {
             pages: number;
-            limit: number;
+            limit: number | "all";
             page: number;
             total: number;
             prev: number | null;
@@ -362,7 +375,7 @@ const result: {
     meta: {
         pagination: {
             pages: number;
-            limit: number;
+            limit: number | "all";
             page: number;
             total: number;
             prev: number | null;
@@ -381,6 +394,11 @@ const result: {
 ```
 
 Here you can use the `next` property to get the next page fetcher if it is defined.
+
+<ContentNavigation
+  previous={{ title: "Overview", href: "/docs/content-api/overview" }}
+  next={{ title: "Read", href: "/docs/content-api/read" }}
+/>
 # Read
 
 The `read` method is used to one item from a Ghost Content API resource, it is the equivalent of the `GET /posts/slug/this-is-a-slug` endpoint. You have to give it an identity field to fetch the resource.
@@ -455,6 +473,11 @@ const result: {
     }[];
 }
 ```
+
+<ContentNavigation
+  previous={{ title: "Browse", href: "/docs/content-api/browse" }}
+  next={{ title: "Output Modifiers", href: "/docs/content-api/output-modifiers" }}
+/>
 # Output modifiers
 
 Output modifiers are available for the `read` and `browse` methods. They let you change the output of the result to have only your selected fields, include some additionnal data that the Ghost API doesn't give you by default or get the content in different formats.
@@ -532,6 +555,11 @@ let result = await api.posts
 ```
 
 The output type will be modified to make the formatted fields you include **non-optionals**.
+
+<ContentNavigation
+  previous={{ title: "Read", href: "/docs/content-api/read" }}
+  next={{ title: "Fetching", href: "/docs/content-api/fetching" }}
+/>
 # Fetching
 
 Fetching happens at the end of your chaining of methods, the moment you call the async `fetch` method (or the async `paginate`).
@@ -571,6 +599,11 @@ let query = await api.posts
   })
   .fetch({ next: { revalidate: 10 } }); // NextJS revalidate this data every 10 seconds at most
 ```
+
+<ContentNavigation
+  previous={{ title: "Output Modifiers", href: "/docs/content-api/output-modifiers" }}
+  next={{ title: "Common Recipes", href: "/docs/content-api/common-recipes" }}
+/>
 # Commons recipes
 
 ## Getting all the posts (including Authors) with pagination
@@ -614,6 +647,11 @@ if (result.success) {
   //     ^? type Settings {title: string; description: string; ...
 }
 ```
+
+<ContentNavigation
+  previous={{ title: "Fetching", href: "/docs/content-api/fetching" }}
+  next={{ title: "Remix", href: "/docs/content-api/remix" }}
+/>
 # Remix example
 
 Here is an example using the `@ts-ghost/content-api` in a Remix loader:
@@ -680,6 +718,11 @@ export default function Index() {
 ```
 
 </Steps>
+
+<ContentNavigation
+  previous={{ title: "Common Recipes", href: "/docs/content-api/common-recipes" }}
+  next={{ title: "NextJS", href: "/docs/content-api/nextjs" }}
+/>
 # NextJS
 
 This is an example for NextJS 13 using the `@ts-ghost/content-api` with the app Router where we fetch the list of posts and the site settings to display them on the `/blog` of our site.
@@ -717,11 +760,8 @@ export const api = new TSGhostContentAPI(
 import { api } from "./ghost";
 
 async function getBlogPosts() {
-  const response = await api.posts
-    .browse()
-    .fields({title: true, slug:true, id:true})
-    .fetch();
-  if(!response.success) {
+  const response = await api.posts.browse().fields({ title: true, slug: true, id: true }).fetch();
+  if (!response.success) {
     throw new Error(response.errors.join(", "));
   }
   return response.data;
@@ -729,7 +769,7 @@ async function getBlogPosts() {
 
 async function getSiteSettings() {
   const response = await api.settings.fetch();
-  if(!response.success) {
+  if (!response.success) {
     throw new Error(response.errors.join(", "));
   }
   return response.data;
@@ -737,21 +777,28 @@ async function getSiteSettings() {
 
 // async Server Component
 export default async function HomePage() {
-  const [posts, settings] = await Promise.all([
-    getBlogPosts(),
-    getSiteSettings()
-  ])
-  return <div>
-    <h1>This is a list of posts for {settings.title}:</h1>
-    <ul>
-      {(posts).map(post => <li key={post.id}>{post.title} ({post.slug})</li>)}
-    </ul>
-
-  </div>;
+  const [posts, settings] = await Promise.all([getBlogPosts(), getSiteSettings()]);
+  return (
+    <div>
+      <h1>This is a list of posts for {settings.title}:</h1>
+      <ul>
+        {posts.map((post) => (
+          <li key={post.id}>
+            {post.title} ({post.slug})
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
 }
 ```
 
 </Steps>
+
+<ContentNavigation
+  previous={{ title: "Remix", href: "/docs/content-api/remix" }}
+  next={{ title: "TypeScript Recipes", href: "/docs/content-api/advanced-typescript" }}
+/>
 # TypeScript recipes
 
 Sometimes TypeScript will get in your way, especially with the string-based type-checking on browse parameters. In this section we will show you some tips and tricks to get around those problems, and present you some utilities.
@@ -805,6 +852,8 @@ const uncontrolledOrderInput = async (formData: FormData) => {
     .fetch();
 };
 ```
+
+<ContentNavigation previous={{ title: "NextJS", href: "/docs/content-api/nextjs" }} />
 
 
 ## Roadmap

--- a/packages/ts-ghost-core-api/src/api-composer.ts
+++ b/packages/ts-ghost-core-api/src/api-composer.ts
@@ -47,7 +47,7 @@ export class APIComposer<
     const FilterStr extends string,
     const P extends {
       order?: OrderStr;
-      limit?: number | string;
+      limit?: number | "all";
       page?: number | string;
       filter?: FilterStr;
     }

--- a/packages/ts-ghost-core-api/src/schemas/shared.ts
+++ b/packages/ts-ghost-core-api/src/schemas/shared.ts
@@ -21,7 +21,7 @@ export const ghostMetaSchema = z.object({
   pagination: z.object({
     pages: z.number(),
     page: z.number(),
-    limit: z.number(),
+    limit: z.union([z.number(), z.literal("all")]),
     total: z.number(),
     prev: z.number().nullable(),
     next: z.number().nullable(),


### PR DESCRIPTION
## Changes

- Possibility to pass limit: "all" to the browse query
- "filter" arg in browse query has now better typing to support for query like "slug:[test,foo]"

## Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/PhilDL/ts-ghost/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
