### PR TITLE
fix: add params options to Posts/Page edit/create

### DIFF
--- a/.changeset/breezy-actors-live.md
+++ b/.changeset/breezy-actors-live.md
@@ -1,0 +1,34 @@
+---
+"@ts-ghost/core-api": minor
+---
+
+### Add updateOptionsSchema to the APIComposer
+
+Resource can now declare an updateOptionsSchema to indicates that some query params are available only when doing update operations.
+
+For example, in the Admin API:
+
+```ts
+return new APIComposer(
+    "posts",
+    {
+    schema: adminPostsSchema,
+    identitySchema: slugOrIdSchema,
+    include: postsIncludeSchema,
+    createSchema: adminPostsCreateSchema,
+    updateSchema: adminPostsUpdateSchema,
+    updateOptionsSchema: z.object({
+        newsletter: z.string().optional(),
+        email_segment: z.string().optional(),
+        force_rerender: z.boolean().optional(),
+        save_revision: z.boolean().optional(),
+        convert_to_lexical: z.boolean().optional(),
+        source: z.literal("html").optional(),
+    }),
+    createOptionsSchema: z.object({
+        source: z.literal("html").optional(),
+    }),
+    },
+    this.httpClient,
+).access(["browse", "read", "add", "edit", "delete"]);
+```

--- a/.changeset/lemon-weeks-wink.md
+++ b/.changeset/lemon-weeks-wink.md
@@ -1,0 +1,73 @@
+---
+"@ts-ghost/admin-api": major
+---
+
+Posts/Pages upgrade: Lexical format as default, handling options (newsletter, source:html, etc) for create/edit mutations.
+
+### `lexical` format availability on posts/pages
+
+- `lexical` format is now available when using the transform `formats` method
+
+```ts
+const result = await api.posts
+  .browse({
+    limit: 1,
+  })
+  .formats({ html: true, plaintext: true })
+  .fetch();
+```
+
+- `lexical` is now the default key returned on posts/page in `admin-api` instead of `html` to take into consideration recent Ghost API changes. To explicitely request `html` you have to specify it in the `formats` object parameter.
+
+### Posts/Page Admin API Edit/Create with `source` option
+
+Using the new `updateOptionSchema` from the core API, the Posts and Pages resource now have optional parameters. Begining with `source`.
+
+**Ghost API now expects `lexical` formatted content by default** so you have to specify `{ source: "html" }` now to keep being able to send html via the API.
+
+```ts
+const postAdd = await api.posts.add(
+  {
+    title: title,
+    html: "<p>Hello from ts-ghost</p>",
+    tags: [{ name: "ts-ghost" }],
+    tiers: [{ name: "ts-ghost" }],
+    custom_excerpt: "This is custom excerpt from ts-ghost",
+    meta_title: "Meta Title from ts-ghost",
+    meta_description: "Description from ts-ghost",
+    featured: true,
+    og_title: "OG Title from ts-ghost",
+    og_description: "OG Description from ts-ghost",
+    twitter_title: "Twitter Title from ts-ghost",
+    twitter_description: "Twitter Description from ts-ghost",
+    visibility: "public",
+  },
+  { source: "html" },
+);
+```
+
+### Posts/Page Admin API Editoptions
+
+Missing options were added to Post and Page **edit**
+
+```ts
+api.posts.edit(
+  newPost.id,
+  {
+    status: "published",
+    updated_at: new Date(newPost.updated_at || ""),
+  },
+  { newsletter: "weekly-newsletter" },
+);
+```
+
+Other options are available to reflect Ghost api changes:
+
+```ts
+newsletter: z.string().optional(),
+email_segment: z.string().optional(),
+force_rerender: z.boolean().optional(),
+save_revision: z.boolean().optional(),
+convert_to_lexical: z.boolean().optional(),
+source: z.literal("html").optional(),
+```

--- a/packages/ts-ghost-admin-api/src/admin-api.ts
+++ b/packages/ts-ghost-admin-api/src/admin-api.ts
@@ -86,6 +86,15 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
         include: pagesIncludeSchema,
         createSchema: adminPagesCreateSchema,
         updateSchema: adminPagesUpdateSchema,
+        updateOptionsSchema: z.object({
+          force_rerender: z.boolean().optional(),
+          save_revision: z.boolean().optional(),
+          convert_to_lexical: z.boolean().optional(),
+          source: z.literal("html").optional(),
+        }),
+        createOptionsSchema: z.object({
+          source: z.literal("html").optional(),
+        }),
       },
       this.httpClient,
     ).access(["browse", "read", "add", "edit", "delete"]);

--- a/packages/ts-ghost-admin-api/src/admin-api.ts
+++ b/packages/ts-ghost-admin-api/src/admin-api.ts
@@ -30,7 +30,7 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
   constructor(
     protected readonly url: string,
     protected readonly key: string,
-    protected readonly version: Version
+    protected readonly version: Version,
   ) {
     const apiCredentials = adminAPICredentialsSchema.parse({
       key,
@@ -56,8 +56,19 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
         include: postsIncludeSchema,
         createSchema: adminPostsCreateSchema,
         updateSchema: adminPostsUpdateSchema,
+        updateOptionsSchema: z.object({
+          newsletter: z.string().optional(),
+          email_segment: z.string().optional(),
+          force_rerender: z.boolean().optional(),
+          save_revision: z.boolean().optional(),
+          convert_to_lexical: z.boolean().optional(),
+          source: z.literal("html").optional(),
+        }),
+        createOptionsSchema: z.object({
+          source: z.literal("html").optional(),
+        }),
       },
-      this.httpClient
+      this.httpClient,
     ).access(["browse", "read", "add", "edit", "delete"]);
   }
 
@@ -76,7 +87,7 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
         createSchema: adminPagesCreateSchema,
         updateSchema: adminPagesUpdateSchema,
       },
-      this.httpClient
+      this.httpClient,
     ).access(["browse", "read", "add", "edit", "delete"]);
   }
 
@@ -92,8 +103,12 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
           send_email: z.boolean().optional(),
           email_type: z.union([z.literal("signin"), z.literal("subscribe"), z.literal("signup")]).optional(),
         }),
+        updateOptionsSchema: z.object({
+          send_email: z.boolean().optional(),
+          email_type: z.union([z.literal("signin"), z.literal("subscribe"), z.literal("signup")]).optional(),
+        }),
       },
-      this.httpClient
+      this.httpClient,
     ).access(["browse", "read", "add", "edit", "delete"]);
   }
 
@@ -111,7 +126,7 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
         include: tiersIncludeSchema,
         createSchema: adminTiersCreateSchema,
       },
-      this.httpClient
+      this.httpClient,
     ).access(["browse", "read"]); // for now tiers mutations don't really work in the admin api
   }
 
@@ -128,7 +143,7 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
           opt_in_existing: z.boolean(),
         }),
       },
-      this.httpClient
+      this.httpClient,
     ).access(["browse", "read", "add", "edit"]);
   }
 
@@ -143,7 +158,7 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
         createSchema: adminOffersCreateSchema,
         updateSchema: adminOffersUpdateSchema,
       },
-      this.httpClient
+      this.httpClient,
     ).access(["browse", "read", "add", "edit"]);
   }
 
@@ -160,7 +175,7 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
         createSchema: adminTagsCreateSchema,
         updateSchema: adminTagsUpdateSchema,
       },
-      this.httpClient
+      this.httpClient,
     ).access(["browse", "read", "add", "edit", "delete"]);
   }
 
@@ -173,7 +188,7 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
         identitySchema: emailOrIdSchema,
         include: usersIncludeSchema,
       },
-      this.httpClient
+      this.httpClient,
     ).access(["browse", "read"]);
   }
 
@@ -187,7 +202,7 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
         createSchema: adminWebhookCreateSchema,
         updateSchema: adminWebhookUpdateSchema,
       },
-      this.httpClient
+      this.httpClient,
     ).access(["add", "edit", "delete"]);
   }
 
@@ -203,10 +218,10 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
           z.object({
             key: z.string(),
             value: z.string().nullable().or(z.number().nullable()).or(z.boolean().nullable()),
-          })
+          }),
         ),
       },
-      this.httpClient
+      this.httpClient,
     );
   }
 }

--- a/packages/ts-ghost-admin-api/src/schemas/posts.integration.test.ts
+++ b/packages/ts-ghost-admin-api/src/schemas/posts.integration.test.ts
@@ -230,7 +230,7 @@ describe("posts integration tests browse", () => {
         limit: 1,
         order: "created_at ASC",
       })
-      .formats({ html: true, plaintext: true })
+      .formats({ html: true, plaintext: true, lexical: true })
       .fetch();
 
     assert(result.success);
@@ -241,6 +241,7 @@ describe("posts integration tests browse", () => {
     expect(post.slug).toBe(stubPost.slug);
     expect(post.title).toBe(stubPost.title);
     expect(post.html).toBeDefined();
+    expect(post.lexical).toBeDefined();
     expect(post.comment_id).toBe(stubPost.comment_id);
     expect(post.feature_image).toBe(stubPost.feature_image);
     expect(post.featured).toBe(stubPost.featured);

--- a/packages/ts-ghost-admin-api/src/schemas/posts.integration.test.ts
+++ b/packages/ts-ghost-admin-api/src/schemas/posts.integration.test.ts
@@ -463,25 +463,29 @@ describe("posts integration tests browse", () => {
 
     const title = faker.hacker.phrase();
 
-    const postAdd = await api.posts.add({
-      title: title,
-      html: "<p>Hello from ts-ghost</p>",
-      tags: [{ name: "ts-ghost" }],
-      tiers: [{ name: "ts-ghost" }],
-      custom_excerpt: "This is custom excerpt from ts-ghost",
-      meta_title: "Meta Title from ts-ghost",
-      meta_description: "Description from ts-ghost",
-      featured: true,
-      og_title: "OG Title from ts-ghost",
-      og_description: "OG Description from ts-ghost",
-      twitter_title: "Twitter Title from ts-ghost",
-      twitter_description: "Twitter Description from ts-ghost",
-      visibility: "public",
-    });
+    const postAdd = await api.posts.add(
+      {
+        title: title,
+        html: "<p>Hello from ts-ghost</p>",
+        tags: [{ name: "ts-ghost" }],
+        tiers: [{ name: "ts-ghost" }],
+        custom_excerpt: "This is custom excerpt from ts-ghost",
+        meta_title: "Meta Title from ts-ghost",
+        meta_description: "Description from ts-ghost",
+        featured: true,
+        og_title: "OG Title from ts-ghost",
+        og_description: "OG Description from ts-ghost",
+        twitter_title: "Twitter Title from ts-ghost",
+        twitter_description: "Twitter Description from ts-ghost",
+        visibility: "public",
+      },
+      { source: "html" },
+    );
     assert(postAdd.success);
     const newPost = postAdd.data;
     expect(newPost.title).toBe(title);
     expect(newPost.slug).toBeDefined();
+    expect(newPost.lexical).toContain("Hello from ts-ghost");
     expect(newPost.custom_excerpt).toBe("This is custom excerpt from ts-ghost");
     expect(newPost.meta_title).toBe("Meta Title from ts-ghost");
     expect(newPost.meta_description).toBe("Description from ts-ghost");
@@ -510,7 +514,7 @@ describe("posts integration tests browse", () => {
     const api = new TSGhostAdminAPI(
       process.env.VITE_GHOST_URL!,
       "1efedd9db174adee2d23d982:4b74dca0219bad629852191af326a45037346c2231240e0f7aec1f9371cc14e8",
-      "v5.0"
+      "v5.0",
     );
     expect(api.posts).toBeDefined();
     const result = await api.posts
@@ -535,7 +539,7 @@ describe("posts integration tests browse", () => {
     const api = new TSGhostAdminAPI(
       "https://codingdodoes.com",
       "1efedd9db174adee2d23d982:4b74dca0219bad629852191af326a45037346c2231240e0f7aec1f9371cc14e8",
-      "v5.0"
+      "v5.0",
     );
     expect(api.posts).toBeDefined();
     const result = await api.posts

--- a/packages/ts-ghost-admin-api/src/schemas/posts.ts
+++ b/packages/ts-ghost-admin-api/src/schemas/posts.ts
@@ -30,6 +30,7 @@ export const adminPostsSchema = basePostsSchema.merge(
         '{"root":{"children":[{"children":[],"direction":null,"format":"","indent":0,"type":"paragraph","version":1}],"direction":null,"format":"","indent":0,"type":"root","version":1}}',
       )
       .optional(),
+    html: z.string().catch("").optional(),
     plaintext: z.string().catch("").optional(),
   }),
 );

--- a/packages/ts-ghost-admin-api/src/schemas/posts.ts
+++ b/packages/ts-ghost-admin-api/src/schemas/posts.ts
@@ -24,9 +24,14 @@ export const adminPostsSchema = basePostsSchema.merge(
       .nullish(),
     authors: z.array(adminAuthorsSchema),
     primary_author: adminAuthorsSchema,
-    html: z.string().catch("").optional(),
+    lexical: z
+      .string()
+      .catch(
+        '{"root":{"children":[{"children":[],"direction":null,"format":"","indent":0,"type":"paragraph","version":1}],"direction":null,"format":"","indent":0,"type":"root","version":1}}',
+      )
+      .optional(),
     plaintext: z.string().catch("").optional(),
-  })
+  }),
 );
 
 export type Post = z.infer<typeof adminPostsSchema>;
@@ -93,7 +98,7 @@ export const adminPostsCreateSchema = z.object({
       ]),
       {
         description: `The tags associated with the post array of either slug, id or name`,
-      }
+      },
     )
     .optional(),
   tiers: z
@@ -111,7 +116,7 @@ export const adminPostsCreateSchema = z.object({
       ]),
       {
         description: `The tiers associated with the post array of either slug, id or name`,
-      }
+      },
     )
     .optional(),
   authors: z
@@ -129,7 +134,7 @@ export const adminPostsCreateSchema = z.object({
       ]),
       {
         description: `Specifing author via id, name or slug.`,
-      }
+      },
     )
     .optional(),
 });
@@ -139,7 +144,7 @@ export type CreatePost = z.infer<typeof adminPostsCreateSchema>;
 export const adminPostsUpdateSchema = adminPostsCreateSchema.partial({ title: true }).merge(
   z.object({
     updated_at: z.date().transform((val) => val.toISOString()),
-  })
+  }),
 );
 
 export type UpdatePost = z.infer<typeof adminPostsUpdateSchema>;

--- a/packages/ts-ghost-core-api/src/api-composer.test.ts
+++ b/packages/ts-ghost-core-api/src/api-composer.test.ts
@@ -48,7 +48,7 @@ describe("APIComposer Read / Browse", () => {
     const composer = new APIComposer(
       "posts",
       { schema: simplifiedSchema, identitySchema: identitySchema, include: simplifiedIncludeSchema },
-      httpClient
+      httpClient,
     );
     expect(composer).toBeDefined();
     expect(composer.browse()).toBeInstanceOf(BrowseFetcher);
@@ -65,14 +65,14 @@ describe("APIComposer Read / Browse", () => {
     const composer = new APIComposer(
       "posts",
       { schema: simplifiedSchema, identitySchema: identitySchema, include: simplifiedIncludeSchema },
-      httpClient
+      httpClient,
     );
     test("pagination params", () => {
       expect(
         composer.browse({
           limit: 10,
           page: 2,
-        })
+        }),
       ).toBeInstanceOf(BrowseFetcher);
     });
 
@@ -80,12 +80,12 @@ describe("APIComposer Read / Browse", () => {
       expect(() =>
         composer.browse({
           limit: 20,
-        })
+        }),
       ).toThrow();
       expect(() =>
         composer.browse({
           limit: -1,
-        })
+        }),
       ).toThrow();
     });
 
@@ -93,7 +93,7 @@ describe("APIComposer Read / Browse", () => {
       expect(() =>
         composer.browse({
           page: 0,
-        })
+        }),
       ).toThrow();
     });
   });
@@ -102,13 +102,13 @@ describe("APIComposer Read / Browse", () => {
     const composer = new APIComposer(
       "posts",
       { schema: simplifiedSchema, identitySchema: identitySchema, include: simplifiedIncludeSchema },
-      httpClient
+      httpClient,
     );
     test("order params should accept a string with correct fields", () => {
       expect(
         composer.browse({
           order: "foo desc",
-        })
+        }),
       ).toBeInstanceOf(BrowseFetcher);
     });
 
@@ -116,7 +116,7 @@ describe("APIComposer Read / Browse", () => {
       expect(
         composer.browse({
           order: "count.posts desc",
-        })
+        }),
       ).toBeInstanceOf(BrowseFetcher);
     });
 
@@ -125,7 +125,7 @@ describe("APIComposer Read / Browse", () => {
         composer.browse({
           // @ts-expect-error - invalid field
           order: "foobarbaz desc",
-        })
+        }),
       ).toThrow();
     });
 
@@ -148,8 +148,8 @@ describe("APIComposer Read / Browse", () => {
       expect(() =>
         composer.browse(
           // @ts-expect-error - invalid field
-          input
-        )
+          input,
+        ),
       ).toThrow();
     });
 
@@ -164,13 +164,13 @@ describe("APIComposer Read / Browse", () => {
     const composer = new APIComposer(
       "posts",
       { schema: simplifiedSchema, identitySchema: identitySchema, include: simplifiedIncludeSchema },
-      httpClient
+      httpClient,
     );
     test("filter params should accept a string with correct fields", () => {
       expect(
         composer.browse({
           filter: "foo:test",
-        })
+        }),
       ).toBeInstanceOf(BrowseFetcher);
     });
 
@@ -178,7 +178,7 @@ describe("APIComposer Read / Browse", () => {
       expect(
         composer.browse({
           filter: "count.posts:test",
-        })
+        }),
       ).toBeInstanceOf(BrowseFetcher);
     });
 
@@ -187,7 +187,7 @@ describe("APIComposer Read / Browse", () => {
         composer.browse({
           // @ts-expect-error - invalid field
           filter: "fo:test",
-        })
+        }),
       ).toThrow();
     });
 
@@ -210,8 +210,8 @@ describe("APIComposer Read / Browse", () => {
       expect(() =>
         composer.browse(
           // @ts-expect-error - invalid field
-          input
-        )
+          input,
+        ),
       ).toThrow();
     });
 
@@ -226,19 +226,19 @@ describe("APIComposer Read / Browse", () => {
     const composer = new APIComposer(
       "posts",
       { schema: simplifiedSchema, identitySchema: identitySchema, include: simplifiedIncludeSchema },
-      httpClient
+      httpClient,
     );
     test("identity read fields params should only accept key from the identity read schema", () => {
       expect(
         composer.read({
           id: "abc",
-        })
+        }),
       ).toBeInstanceOf(ReadFetcher);
 
       expect(
         composer.read({
           slug: "foo-bar",
-        })
+        }),
       ).toBeInstanceOf(ReadFetcher);
     });
 
@@ -247,7 +247,7 @@ describe("APIComposer Read / Browse", () => {
         composer.read({
           // @ts-expect-error - invalid field
           foo: "foobarbaz",
-        })
+        }),
       ).toThrow();
     });
   });
@@ -256,7 +256,7 @@ describe("APIComposer Read / Browse", () => {
     const composer = new APIComposer(
       "posts",
       { schema: simplifiedSchema, identitySchema: identitySchema, include: simplifiedIncludeSchema },
-      httpClient
+      httpClient,
     );
     test("include params should only accept key from the include schema", () => {
       expect(composer.browse()).toBeInstanceOf(BrowseFetcher);
@@ -322,8 +322,11 @@ describe("APIComposer add / edit", () => {
         // updateSchema: z.object({
         //   foobar: z.string(),
         // }),
+        updateOptionsSchema: z.object({
+          update_option_1: z.boolean(),
+        }),
       },
-      httpClient
+      httpClient,
     );
     expect(composer).toBeDefined();
     expect(composer.browse()).toBeInstanceOf(BrowseFetcher);
@@ -343,6 +346,10 @@ describe("APIComposer add / edit", () => {
     // @ts-expect-error - edit without data
     expect(() => composer.edit("abc")).rejects.toThrow();
     expect(() => composer.edit("", { foo: "test" })).rejects.toThrow();
+
+    // @ts-expect-error - edit known fields but unknown option
+    expect(() => composer.edit("abc", { foo: "test" }, { update_otion_1: true })).rejects.toThrow();
+    expect(await composer.edit("abc", { foo: "test" }, { update_option_1: true })).toBeDefined();
   });
 
   test("post add", async () => {
@@ -360,7 +367,7 @@ describe("APIComposer add / edit", () => {
         //   foobar: z.string(),
         // }),
       },
-      httpClient
+      httpClient,
     );
     fetchMocker.doMockOnce(
       JSON.stringify({
@@ -371,7 +378,7 @@ describe("APIComposer add / edit", () => {
             bar: "foobaz",
           },
         ],
-      })
+      }),
     );
     const result = await composer.add({ foo: "abc@test.com" });
     expect(fetchMocker).toBeCalledWith("https://ghost.org/ghost/api/content/posts/?key=1234", {
@@ -426,7 +433,7 @@ describe("APIComposer add / edit", () => {
         //   foobar: z.string(),
         // }),
       },
-      httpClient
+      httpClient,
     );
     const mockData = {
       id: "abc",
@@ -436,7 +443,7 @@ describe("APIComposer add / edit", () => {
     fetchMocker.doMockOnce(
       JSON.stringify({
         posts: [mockData],
-      })
+      }),
     );
     const result = await composer.add({ foo: "new foo" }, { option_1: true });
 
@@ -473,7 +480,7 @@ describe("APIComposer add / edit", () => {
         //   foobar: z.string(),
         // }),
       },
-      httpClient
+      httpClient,
     );
     fetchMocker.doMockOnce(
       JSON.stringify({
@@ -490,7 +497,7 @@ describe("APIComposer add / edit", () => {
             ghostErrorCode: null,
           },
         ],
-      })
+      }),
     );
     const result = await composer.add({ foo: "existing" }, { option_1: true });
 
@@ -533,7 +540,7 @@ describe("APIComposer add / edit", () => {
         //   foobar: z.string(),
         // }),
       },
-      httpClient
+      httpClient,
     );
     fetchMocker.doMockOnce(
       JSON.stringify({
@@ -544,7 +551,7 @@ describe("APIComposer add / edit", () => {
             bar: "foobaz",
           },
         ],
-      })
+      }),
     );
     const result = await composer.edit("abc", { foo: "new foo" });
     expect(fetchMocker).toBeCalledWith("https://ghost.org/ghost/api/content/posts/abc/?key=1234", {
@@ -570,6 +577,64 @@ describe("APIComposer add / edit", () => {
     });
   });
 
+  test("put edit with options", async () => {
+    const composer = new APIComposer(
+      "posts",
+      {
+        schema: simplifiedSchema,
+        identitySchema: identitySchema,
+        include: simplifiedIncludeSchema,
+        createSchema,
+        createOptionsSchema: z.object({
+          option_1: z.boolean(),
+        }),
+        // updateSchema: z.object({
+        //   foobar: z.string(),
+        // }),
+        updateOptionsSchema: z.object({
+          newsletter: z.string().optional(),
+        }),
+      },
+      httpClient,
+    );
+    fetchMocker.doMockOnce(
+      JSON.stringify({
+        posts: [
+          {
+            id: "abc",
+            foo: "new foo",
+            bar: "foobaz",
+          },
+        ],
+      }),
+    );
+    const result = await composer.edit("abc", { foo: "new foo" }, { newsletter: "nsl" });
+    expect(fetchMocker).toBeCalledWith(
+      "https://ghost.org/ghost/api/content/posts/abc/?newsletter=nsl&key=1234",
+      {
+        method: "PUT",
+        headers: {
+          "Accept-Version": "v5.0",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          posts: [
+            {
+              foo: "new foo",
+            },
+          ],
+        }),
+      },
+    );
+    assert(result.success);
+    const post = result.data;
+    expect(post).toStrictEqual({
+      id: "abc",
+      foo: "new foo",
+      bar: "foobaz",
+    });
+  });
+
   test("put edit fail", async () => {
     const composer = new APIComposer(
       "posts",
@@ -585,7 +650,7 @@ describe("APIComposer add / edit", () => {
         //   foobar: z.string(),
         // }),
       },
-      httpClient
+      httpClient,
     );
     fetchMocker.doMockOnce(
       JSON.stringify({
@@ -602,7 +667,7 @@ describe("APIComposer add / edit", () => {
             ghostErrorCode: null,
           },
         ],
-      })
+      }),
     );
 
     const result = await composer.edit("abc", { foo: "new foo" });

--- a/packages/ts-ghost-core-api/src/fetchers/browse-fetcher.ts
+++ b/packages/ts-ghost-core-api/src/fetchers/browse-fetcher.ts
@@ -4,6 +4,7 @@ import { BrowseParamsSchema } from "../helpers/browse-params";
 import type { HTTPClient } from "../helpers/http-client";
 import { ghostMetaSchema, type APIResource } from "../schemas/shared";
 import type { Mask } from "../utils";
+import { contentFormats, type ContentFormats } from "./formats";
 
 export class BrowseFetcher<
   const Resource extends APIResource = any,
@@ -43,12 +44,12 @@ export class BrowseFetcher<
    * @param formats html, mobiledoc or plaintext
    * @returns A new Fetcher with the fixed output shape and the formats specified
    */
-  public formats<Formats extends Mask<Pick<OutputShape, "html" | "mobiledoc" | "plaintext">>>(
+  public formats<Formats extends Mask<Pick<OutputShape, ContentFormats>>>(
     formats: z.noUnrecognized<Formats, OutputShape>,
   ) {
     const params = {
       ...this._params,
-      formats: Object.keys(formats).filter((key) => ["html", "mobiledoc", "plaintext"].includes(key)),
+      formats: Object.keys(formats).filter((key) => contentFormats.includes(key)),
     };
     return new BrowseFetcher(
       this.resource,

--- a/packages/ts-ghost-core-api/src/fetchers/formats.ts
+++ b/packages/ts-ghost-core-api/src/fetchers/formats.ts
@@ -1,0 +1,2 @@
+export type ContentFormats = "html" | "mobiledoc" | "plaintext" | "lexical";
+export const contentFormats = ["html", "mobiledoc", "plaintext", "lexical"];

--- a/packages/ts-ghost-core-api/src/fetchers/read-fetcher.ts
+++ b/packages/ts-ghost-core-api/src/fetchers/read-fetcher.ts
@@ -3,13 +3,14 @@ import { z, ZodRawShape } from "zod";
 import type { HTTPClient } from "../helpers/http-client";
 import { type APIResource, type GhostIdentityInput } from "../schemas/shared";
 import type { Mask } from "../utils";
+import { contentFormats, type ContentFormats } from "./formats";
 
 export class ReadFetcher<
   const Resource extends APIResource = any,
   Fields extends Mask<OutputShape> = any,
   BaseShape extends ZodRawShape = any,
   OutputShape extends ZodRawShape = any,
-  IncludeShape extends ZodRawShape = any
+  IncludeShape extends ZodRawShape = any,
 > {
   protected _urlParams: Record<string, string> = {};
   protected _urlSearchParams: URLSearchParams | undefined = undefined;
@@ -29,7 +30,7 @@ export class ReadFetcher<
       fields?: Fields;
       formats?: string[];
     },
-    protected httpClient: HTTPClient
+    protected httpClient: HTTPClient,
   ) {
     this._buildUrlParams();
   }
@@ -42,12 +43,12 @@ export class ReadFetcher<
    * @param formats html, mobiledoc or plaintext
    * @returns A new Fetcher with the fixed output shape and the formats specified
    */
-  public formats<Formats extends Mask<Pick<OutputShape, "html" | "mobiledoc" | "plaintext">>>(
-    formats: z.noUnrecognized<Formats, OutputShape>
+  public formats<Formats extends Mask<Pick<OutputShape, ContentFormats>>>(
+    formats: z.noUnrecognized<Formats, OutputShape>,
   ) {
     const params = {
       ...this._params,
-      formats: Object.keys(formats).filter((key) => ["html", "mobiledoc", "plaintext"].includes(key)),
+      formats: Object.keys(formats).filter((key) => contentFormats.includes(key)),
     };
     return new ReadFetcher(
       this.resource,
@@ -57,7 +58,7 @@ export class ReadFetcher<
         include: this.config.include,
       },
       params,
-      this.httpClient
+      this.httpClient,
     );
   }
 
@@ -82,7 +83,7 @@ export class ReadFetcher<
         include: this.config.include,
       },
       params,
-      this.httpClient
+      this.httpClient,
     );
   }
 
@@ -103,7 +104,7 @@ export class ReadFetcher<
         include: this.config.include,
       },
       this._params,
-      this.httpClient
+      this.httpClient,
     );
   }
 
@@ -168,7 +169,7 @@ export class ReadFetcher<
           z.object({
             type: z.string(),
             message: z.string(),
-          })
+          }),
         ),
       }),
     ]);


### PR DESCRIPTION
Closes #188 

## Changes

## `ts-ghost/core-api` 

### new `updateOptionsSchema`

Resource can now declare an `updateOptionsSchema` to indicates that some query params are available only when doing update operations. 

## `ts-ghost/admin-api`
### `lexical` format availability on posts/pages

- `lexical` format is now available when using the transform `formats` method
```ts
const result = await api.posts
      .browse({
        limit: 1,
      })
      .formats({ html: true, plaintext: true })
      .fetch();
```

- `lexical` is now the default key returned on posts/page in `admin-api` instead of `html` to take into consideration recent Ghost API changes. To explicitely request `html` you have to specify it in the `formats` object parameter.


### Posts/Page Admin API Edit/Create with `source` option

Using the new `updateOptionSchema` from the core API, the Posts and Pages resource now have optional parameters. Begining with `source`.

**Ghost API now expects `lexical` formatted content by default** so you have to specify `{ source: "html" }` now to keep being able to send html via the API.

```ts
const postAdd = await api.posts.add(
      {
        title: title,
        html: "<p>Hello from ts-ghost</p>",
        tags: [{ name: "ts-ghost" }],
        tiers: [{ name: "ts-ghost" }],
        custom_excerpt: "This is custom excerpt from ts-ghost",
        meta_title: "Meta Title from ts-ghost",
        meta_description: "Description from ts-ghost",
        featured: true,
        og_title: "OG Title from ts-ghost",
        og_description: "OG Description from ts-ghost",
        twitter_title: "Twitter Title from ts-ghost",
        twitter_description: "Twitter Description from ts-ghost",
        visibility: "public",
      },
      { source: "html" },
    );
```

### Posts/Page Admin API Editoptions

Missing options were added to Post and Page **edit**

```ts
api.posts.edit(
      newPost.id,
      {
        status: 'published',
        updated_at: new Date(newPost.updated_at || ''),
      },
      { newsletter: 'weekly-newsletter' }
    );
```

Other options are available to reflect Ghost api changes:
```ts
newsletter: z.string().optional(),
email_segment: z.string().optional(),
force_rerender: z.boolean().optional(),
save_revision: z.boolean().optional(),
convert_to_lexical: z.boolean().optional(),
source: z.literal("html").optional(),
```

## Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/PhilDL/ts-ghost/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
