### PR TITLE
Fix admin-api publish post with newsletter: bad email schema

### DIFF
--- a/.changeset/pink-pandas-teach.md
+++ b/.changeset/pink-pandas-teach.md
@@ -1,0 +1,8 @@
+---
+"@ts-ghost/core-api": patch
+---
+
+fix bug of parsing response when publishing a post with a newsletter. The email object was not correct, schema was out of date with the new lexical norm:
+
+- `plaintext`, `html` are now nullable
+- `source` is a new string containing the lexical tree

--- a/packages/ts-ghost-core-api/src/schemas/email.ts
+++ b/packages/ts-ghost-core-api/src/schemas/email.ts
@@ -13,9 +13,10 @@ export const baseEmailSchema = z.object({
   failed_count: z.number(),
   subject: z.string(),
   from: z.string(),
-  reply_to: z.string(),
-  html: z.string(),
-  plaintext: z.string(),
+  reply_to: z.string().nullable(),
+  source: z.string(), // lexical format
+  html: z.string().nullable(),
+  plaintext: z.string().nullable(),
   track_opens: z.boolean(),
   submitted_at: z.string(),
   created_at: z.string(),


### PR DESCRIPTION
Closes #188 

## Minor changes

- admin-api: fix bug of parsing response when publishing a post with a newsletter. The `email` object was not correct, schema was out of date with the new lexical norm:
    - `plaintext`, `html` are now nullable
    - `source` is a new string containing the lexical tree

## Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/PhilDL/ts-ghost/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
