### PR TITLE
fix bugs when reusing the same instance of the inner HTTPClient

### DIFF
--- a/.changeset/angry-geckos-cry.md
+++ b/.changeset/angry-geckos-cry.md
@@ -1,0 +1,7 @@
+---
+"@ts-ghost/admin-api": minor
+"@ts-ghost/core-api": minor
+---
+
+Internals change of the API Composer instantiation to use the new HTTPClientFactory instead of direct instances.
+There is no user-level change required.

--- a/.changeset/curvy-deers-think.md
+++ b/.changeset/curvy-deers-think.md
@@ -1,0 +1,30 @@
+---
+"@ts-ghost/core-api": major
+---
+
+API Composer now require an HTTPClientFactory instead of a HTTPClient.
+
+Passing directly an instanciated HTTPClient was creating a lot of issues with the HttpClient lifecycle. Now, you need to pass a factory that will be used to create a new HttpClient for each request.
+
+The HTTPClientFactory takes the same parameters as the HttpClient constructor, so you can pass the same configuration.
+
+```typescript
+export type HTTPClientOptions = {
+  key: string;
+  version: APICredentials["version"];
+  url: APICredentials["url"];
+  endpoint: "content" | "admin";
+};
+
+export interface IHTTPClientFactory {
+  create(config: HTTPClientOptions): HTTPClient;
+}
+
+export class HTTPClientFactory implements IHTTPClientFactory {
+  constructor(private config: HTTPClientOptions) {}
+
+  public create() {
+    return new HTTPClient(this.config);
+  }
+}
+```

--- a/packages/ts-ghost-admin-api/src/admin-api.ts
+++ b/packages/ts-ghost-admin-api/src/admin-api.ts
@@ -25,21 +25,21 @@ import { adminWebhookCreateSchema, adminWebhookSchema, adminWebhookUpdateSchema 
 export type { AdminAPICredentials, APIVersions } from "@ts-ghost/core-api";
 
 export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
-  private httpClient: HTTPClient;
+  private credentials: {
+    key: string;
+    version: string;
+    url: string;
+  };
 
   constructor(
     protected readonly url: string,
     protected readonly key: string,
     protected readonly version: Version,
   ) {
-    const apiCredentials = adminAPICredentialsSchema.parse({
+    this.credentials = adminAPICredentialsSchema.parse({
       key,
       version,
       url,
-    });
-    this.httpClient = new HTTPClient({
-      ...apiCredentials,
-      endpoint: "admin",
     });
   }
   get posts() {
@@ -68,7 +68,10 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
           source: z.literal("html").optional(),
         }),
       },
-      this.httpClient,
+      new HTTPClient({
+        ...this.credentials,
+        endpoint: "admin",
+      }),
     ).access(["browse", "read", "add", "edit", "delete"]);
   }
 
@@ -96,7 +99,10 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
           source: z.literal("html").optional(),
         }),
       },
-      this.httpClient,
+      new HTTPClient({
+        ...this.credentials,
+        endpoint: "admin",
+      }),
     ).access(["browse", "read", "add", "edit", "delete"]);
   }
 
@@ -117,7 +123,10 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
           email_type: z.union([z.literal("signin"), z.literal("subscribe"), z.literal("signup")]).optional(),
         }),
       },
-      this.httpClient,
+      new HTTPClient({
+        ...this.credentials,
+        endpoint: "admin",
+      }),
     ).access(["browse", "read", "add", "edit", "delete"]);
   }
 
@@ -135,7 +144,10 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
         include: tiersIncludeSchema,
         createSchema: adminTiersCreateSchema,
       },
-      this.httpClient,
+      new HTTPClient({
+        ...this.credentials,
+        endpoint: "admin",
+      }),
     ).access(["browse", "read"]); // for now tiers mutations don't really work in the admin api
   }
 
@@ -152,7 +164,10 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
           opt_in_existing: z.boolean(),
         }),
       },
-      this.httpClient,
+      new HTTPClient({
+        ...this.credentials,
+        endpoint: "admin",
+      }),
     ).access(["browse", "read", "add", "edit"]);
   }
 
@@ -167,7 +182,10 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
         createSchema: adminOffersCreateSchema,
         updateSchema: adminOffersUpdateSchema,
       },
-      this.httpClient,
+      new HTTPClient({
+        ...this.credentials,
+        endpoint: "admin",
+      }),
     ).access(["browse", "read", "add", "edit"]);
   }
 
@@ -184,7 +202,10 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
         createSchema: adminTagsCreateSchema,
         updateSchema: adminTagsUpdateSchema,
       },
-      this.httpClient,
+      new HTTPClient({
+        ...this.credentials,
+        endpoint: "admin",
+      }),
     ).access(["browse", "read", "add", "edit", "delete"]);
   }
 
@@ -197,7 +218,10 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
         identitySchema: emailOrIdSchema,
         include: usersIncludeSchema,
       },
-      this.httpClient,
+      new HTTPClient({
+        ...this.credentials,
+        endpoint: "admin",
+      }),
     ).access(["browse", "read"]);
   }
 
@@ -211,12 +235,22 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
         createSchema: adminWebhookCreateSchema,
         updateSchema: adminWebhookUpdateSchema,
       },
-      this.httpClient,
+      new HTTPClient({
+        ...this.credentials,
+        endpoint: "admin",
+      }),
     ).access(["add", "edit", "delete"]);
   }
 
   get site() {
-    return new BasicFetcher("site", { output: baseSiteSchema }, this.httpClient);
+    return new BasicFetcher(
+      "site",
+      { output: baseSiteSchema },
+      new HTTPClient({
+        ...this.credentials,
+        endpoint: "admin",
+      }),
+    );
   }
 
   get settings() {
@@ -230,7 +264,10 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
           }),
         ),
       },
-      this.httpClient,
+      new HTTPClient({
+        ...this.credentials,
+        endpoint: "admin",
+      }),
     );
   }
 }

--- a/packages/ts-ghost-admin-api/src/admin-api.ts
+++ b/packages/ts-ghost-admin-api/src/admin-api.ts
@@ -8,7 +8,7 @@ import {
   baseTagsSchema,
   BasicFetcher,
   emailOrIdSchema,
-  HTTPClient,
+  HTTPClientFactory,
   slugOrIdSchema,
 } from "@ts-ghost/core-api";
 
@@ -25,7 +25,7 @@ import { adminWebhookCreateSchema, adminWebhookSchema, adminWebhookUpdateSchema 
 export type { AdminAPICredentials, APIVersions } from "@ts-ghost/core-api";
 
 export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
-  private httpClient: HTTPClient;
+  private httpClientFactory: HTTPClientFactory;
 
   constructor(
     protected readonly url: string,
@@ -37,7 +37,7 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
       version,
       url,
     });
-    this.httpClient = new HTTPClient({
+    this.httpClientFactory = new HTTPClientFactory({
       ...apiCredentials,
       endpoint: "admin",
     });
@@ -68,7 +68,7 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
           source: z.literal("html").optional(),
         }),
       },
-      this.httpClient,
+      this.httpClientFactory,
     ).access(["browse", "read", "add", "edit", "delete"]);
   }
 
@@ -96,7 +96,7 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
           source: z.literal("html").optional(),
         }),
       },
-      this.httpClient,
+      this.httpClientFactory,
     ).access(["browse", "read", "add", "edit", "delete"]);
   }
 
@@ -117,7 +117,7 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
           email_type: z.union([z.literal("signin"), z.literal("subscribe"), z.literal("signup")]).optional(),
         }),
       },
-      this.httpClient,
+      this.httpClientFactory,
     ).access(["browse", "read", "add", "edit", "delete"]);
   }
 
@@ -135,7 +135,7 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
         include: tiersIncludeSchema,
         createSchema: adminTiersCreateSchema,
       },
-      this.httpClient,
+      this.httpClientFactory,
     ).access(["browse", "read"]); // for now tiers mutations don't really work in the admin api
   }
 
@@ -152,7 +152,7 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
           opt_in_existing: z.boolean(),
         }),
       },
-      this.httpClient,
+      this.httpClientFactory,
     ).access(["browse", "read", "add", "edit"]);
   }
 
@@ -167,7 +167,7 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
         createSchema: adminOffersCreateSchema,
         updateSchema: adminOffersUpdateSchema,
       },
-      this.httpClient,
+      this.httpClientFactory,
     ).access(["browse", "read", "add", "edit"]);
   }
 
@@ -184,7 +184,7 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
         createSchema: adminTagsCreateSchema,
         updateSchema: adminTagsUpdateSchema,
       },
-      this.httpClient,
+      this.httpClientFactory,
     ).access(["browse", "read", "add", "edit", "delete"]);
   }
 
@@ -197,7 +197,7 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
         identitySchema: emailOrIdSchema,
         include: usersIncludeSchema,
       },
-      this.httpClient,
+      this.httpClientFactory,
     ).access(["browse", "read"]);
   }
 
@@ -211,12 +211,12 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
         createSchema: adminWebhookCreateSchema,
         updateSchema: adminWebhookUpdateSchema,
       },
-      this.httpClient,
+      this.httpClientFactory,
     ).access(["add", "edit", "delete"]);
   }
 
   get site() {
-    return new BasicFetcher("site", { output: baseSiteSchema }, this.httpClient);
+    return new BasicFetcher("site", { output: baseSiteSchema }, this.httpClientFactory.create());
   }
 
   get settings() {
@@ -230,7 +230,7 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
           }),
         ),
       },
-      this.httpClient,
+      this.httpClientFactory.create(),
     );
   }
 }

--- a/packages/ts-ghost-admin-api/src/admin-api.ts
+++ b/packages/ts-ghost-admin-api/src/admin-api.ts
@@ -25,21 +25,21 @@ import { adminWebhookCreateSchema, adminWebhookSchema, adminWebhookUpdateSchema 
 export type { AdminAPICredentials, APIVersions } from "@ts-ghost/core-api";
 
 export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
-  private credentials: {
-    key: string;
-    version: string;
-    url: string;
-  };
+  private httpClient: HTTPClient;
 
   constructor(
     protected readonly url: string,
     protected readonly key: string,
     protected readonly version: Version,
   ) {
-    this.credentials = adminAPICredentialsSchema.parse({
+    const apiCredentials = adminAPICredentialsSchema.parse({
       key,
       version,
       url,
+    });
+    this.httpClient = new HTTPClient({
+      ...apiCredentials,
+      endpoint: "admin",
     });
   }
   get posts() {
@@ -68,10 +68,7 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
           source: z.literal("html").optional(),
         }),
       },
-      new HTTPClient({
-        ...this.credentials,
-        endpoint: "admin",
-      }),
+      this.httpClient,
     ).access(["browse", "read", "add", "edit", "delete"]);
   }
 
@@ -99,10 +96,7 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
           source: z.literal("html").optional(),
         }),
       },
-      new HTTPClient({
-        ...this.credentials,
-        endpoint: "admin",
-      }),
+      this.httpClient,
     ).access(["browse", "read", "add", "edit", "delete"]);
   }
 
@@ -123,10 +117,7 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
           email_type: z.union([z.literal("signin"), z.literal("subscribe"), z.literal("signup")]).optional(),
         }),
       },
-      new HTTPClient({
-        ...this.credentials,
-        endpoint: "admin",
-      }),
+      this.httpClient,
     ).access(["browse", "read", "add", "edit", "delete"]);
   }
 
@@ -144,10 +135,7 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
         include: tiersIncludeSchema,
         createSchema: adminTiersCreateSchema,
       },
-      new HTTPClient({
-        ...this.credentials,
-        endpoint: "admin",
-      }),
+      this.httpClient,
     ).access(["browse", "read"]); // for now tiers mutations don't really work in the admin api
   }
 
@@ -164,10 +152,7 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
           opt_in_existing: z.boolean(),
         }),
       },
-      new HTTPClient({
-        ...this.credentials,
-        endpoint: "admin",
-      }),
+      this.httpClient,
     ).access(["browse", "read", "add", "edit"]);
   }
 
@@ -182,10 +167,7 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
         createSchema: adminOffersCreateSchema,
         updateSchema: adminOffersUpdateSchema,
       },
-      new HTTPClient({
-        ...this.credentials,
-        endpoint: "admin",
-      }),
+      this.httpClient,
     ).access(["browse", "read", "add", "edit"]);
   }
 
@@ -202,10 +184,7 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
         createSchema: adminTagsCreateSchema,
         updateSchema: adminTagsUpdateSchema,
       },
-      new HTTPClient({
-        ...this.credentials,
-        endpoint: "admin",
-      }),
+      this.httpClient,
     ).access(["browse", "read", "add", "edit", "delete"]);
   }
 
@@ -218,10 +197,7 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
         identitySchema: emailOrIdSchema,
         include: usersIncludeSchema,
       },
-      new HTTPClient({
-        ...this.credentials,
-        endpoint: "admin",
-      }),
+      this.httpClient,
     ).access(["browse", "read"]);
   }
 
@@ -235,22 +211,12 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
         createSchema: adminWebhookCreateSchema,
         updateSchema: adminWebhookUpdateSchema,
       },
-      new HTTPClient({
-        ...this.credentials,
-        endpoint: "admin",
-      }),
+      this.httpClient,
     ).access(["add", "edit", "delete"]);
   }
 
   get site() {
-    return new BasicFetcher(
-      "site",
-      { output: baseSiteSchema },
-      new HTTPClient({
-        ...this.credentials,
-        endpoint: "admin",
-      }),
-    );
+    return new BasicFetcher("site", { output: baseSiteSchema }, this.httpClient);
   }
 
   get settings() {
@@ -264,10 +230,7 @@ export class TSGhostAdminAPI<Version extends `v5.${string}` = any> {
           }),
         ),
       },
-      new HTTPClient({
-        ...this.credentials,
-        endpoint: "admin",
-      }),
+      this.httpClient,
     );
   }
 }

--- a/packages/ts-ghost-admin-api/src/schemas/posts.integration.test.ts
+++ b/packages/ts-ghost-admin-api/src/schemas/posts.integration.test.ts
@@ -511,6 +511,34 @@ describe("posts integration tests browse", () => {
     assert(postDelete.success);
   });
 
+  test("fetchers are seperated instances", async () => {
+    expect(api.posts).toBeDefined();
+
+    const result = await api.posts.add(
+      {
+        title: faker.hacker.phrase(),
+        html: "<p>Super Hello from ts-ghost</p>",
+      },
+      { source: "html" },
+    );
+    expect(result.success).toBeTruthy();
+    const result2 = await api.posts.add(
+      {
+        title: faker.hacker.phrase(),
+        html: "<p>Super Hello from ts-ghost2</p>",
+      },
+      { source: "html" },
+    );
+    expect(result2.success).toBeTruthy();
+
+    const [a, b] = await Promise.all([
+      api.posts.delete((result.success && result.data.id) || ""),
+      api.posts.delete((result2.success && result2.data.id) || ""),
+    ]);
+    expect(a.success).toBeTruthy();
+    expect(b.success).toBeTruthy();
+  });
+
   test("posts api with bad key", async () => {
     const api = new TSGhostAdminAPI(
       process.env.VITE_GHOST_URL!,

--- a/packages/ts-ghost-admin-api/src/schemas/posts.test.ts
+++ b/packages/ts-ghost-admin-api/src/schemas/posts.test.ts
@@ -21,34 +21,3 @@ describe("posts api .browse() Args Type-safety", () => {
     expect(() => api.posts.browse({ filter: "slug:test,food:-[bar,baz]" })).toThrow();
   });
 });
-
-describe("check that fetchers are seperated instances", () => {
-  test("fetchers are seperated instances", async () => {
-    const url = process.env.VITE_GHOST_URL || "https://my-ghost-blog.com";
-    const key =
-      process.env.VITE_GHOST_ADMIN_API_KEY ||
-      "1efedd9db174adee2d23d982:4b74dca0219bad629852191af326a45037346c2231240e0f7aec1f9371cc14e8";
-    const api = new TSGhostAdminAPI(url, key, "v5.0");
-
-    const result = await api.posts.add(
-      {
-        title: "Its not working",
-        html: "<p>Super Hello from ts-ghost</p>",
-      },
-      { source: "html" },
-    );
-    const result2 = await api.posts.add(
-      {
-        title: "Its not working2",
-        html: "<p>Super Hello from ts-ghost2</p>",
-      },
-      { source: "html" },
-    );
-    const [a, b] = await Promise.all([
-      api.posts.delete((result.success && result.data.id) || ""),
-      api.posts.delete((result2.success && result2.data.id) || ""),
-    ]);
-    expect(a.success).toBeTruthy();
-    expect(b.success).toBeTruthy();
-  });
-});

--- a/packages/ts-ghost-admin-api/src/schemas/posts.test.ts
+++ b/packages/ts-ghost-admin-api/src/schemas/posts.test.ts
@@ -21,3 +21,34 @@ describe("posts api .browse() Args Type-safety", () => {
     expect(() => api.posts.browse({ filter: "slug:test,food:-[bar,baz]" })).toThrow();
   });
 });
+
+describe("check that fetchers are seperated instances", () => {
+  test("fetchers are seperated instances", async () => {
+    const url = process.env.VITE_GHOST_URL || "https://my-ghost-blog.com";
+    const key =
+      process.env.VITE_GHOST_ADMIN_API_KEY ||
+      "1efedd9db174adee2d23d982:4b74dca0219bad629852191af326a45037346c2231240e0f7aec1f9371cc14e8";
+    const api = new TSGhostAdminAPI(url, key, "v5.0");
+
+    const result = await api.posts.add(
+      {
+        title: "Its not working",
+        html: "<p>Super Hello from ts-ghost</p>",
+      },
+      { source: "html" },
+    );
+    const result2 = await api.posts.add(
+      {
+        title: "Its not working2",
+        html: "<p>Super Hello from ts-ghost2</p>",
+      },
+      { source: "html" },
+    );
+    const [a, b] = await Promise.all([
+      api.posts.delete((result.success && result.data.id) || ""),
+      api.posts.delete((result2.success && result2.data.id) || ""),
+    ]);
+    expect(a.success).toBeTruthy();
+    expect(b.success).toBeTruthy();
+  });
+});

--- a/packages/ts-ghost-content-api/src/content-api.ts
+++ b/packages/ts-ghost-content-api/src/content-api.ts
@@ -25,21 +25,21 @@ export enum BrowseEndpointType {
 }
 
 export class TSGhostContentAPI<Version extends `v5.${string}` = any> {
-  private httpClient: HTTPClient;
+  private credentials: {
+    url: string;
+    key: string;
+    version: string;
+  };
 
   constructor(
     protected readonly url: string,
     protected readonly key: string,
-    protected readonly version: Version
+    protected readonly version: Version,
   ) {
-    const apiCredentials = contentAPICredentialsSchema.parse({
+    this.credentials = contentAPICredentialsSchema.parse({
       key,
       version,
       url,
-    });
-    this.httpClient = new HTTPClient({
-      ...apiCredentials,
-      endpoint: "content",
     });
   }
 
@@ -51,14 +51,20 @@ export class TSGhostContentAPI<Version extends `v5.${string}` = any> {
         identitySchema: slugOrIdSchema,
         include: authorsIncludeSchema,
       },
-      this.httpClient
+      new HTTPClient({
+        ...this.credentials,
+        endpoint: "content",
+      }),
     ).access(["read", "browse"]);
   }
   get tiers() {
     return new APIComposer(
       "tiers",
       { schema: tiersSchema, identitySchema: slugOrIdSchema, include: tiersIncludeSchema },
-      this.httpClient
+      new HTTPClient({
+        ...this.credentials,
+        endpoint: "content",
+      }),
     ).access(["browse", "read"]);
   }
   get posts() {
@@ -69,7 +75,10 @@ export class TSGhostContentAPI<Version extends `v5.${string}` = any> {
         identitySchema: slugOrIdSchema,
         include: postsIncludeSchema,
       },
-      this.httpClient
+      new HTTPClient({
+        ...this.credentials,
+        endpoint: "content",
+      }),
     ).access(["browse", "read"]);
   }
   get pages() {
@@ -80,18 +89,31 @@ export class TSGhostContentAPI<Version extends `v5.${string}` = any> {
         identitySchema: slugOrIdSchema,
         include: pagesIncludeSchema,
       },
-      this.httpClient
+      new HTTPClient({
+        ...this.credentials,
+        endpoint: "content",
+      }),
     ).access(["browse", "read"]);
   }
   get tags() {
     return new APIComposer(
       "tags",
       { schema: tagsSchema, identitySchema: slugOrIdSchema, include: tagsIncludeSchema },
-      this.httpClient
+      new HTTPClient({
+        ...this.credentials,
+        endpoint: "content",
+      }),
     ).access(["browse", "read"]);
   }
 
   get settings() {
-    return new BasicFetcher("settings", { output: settingsSchema }, this.httpClient);
+    return new BasicFetcher(
+      "settings",
+      { output: settingsSchema },
+      new HTTPClient({
+        ...this.credentials,
+        endpoint: "content",
+      }),
+    );
   }
 }

--- a/packages/ts-ghost-content-api/src/content-api.ts
+++ b/packages/ts-ghost-content-api/src/content-api.ts
@@ -25,21 +25,21 @@ export enum BrowseEndpointType {
 }
 
 export class TSGhostContentAPI<Version extends `v5.${string}` = any> {
-  private credentials: {
-    url: string;
-    key: string;
-    version: string;
-  };
+  private httpClient: HTTPClient;
 
   constructor(
     protected readonly url: string,
     protected readonly key: string,
-    protected readonly version: Version,
+    protected readonly version: Version
   ) {
-    this.credentials = contentAPICredentialsSchema.parse({
+    const apiCredentials = contentAPICredentialsSchema.parse({
       key,
       version,
       url,
+    });
+    this.httpClient = new HTTPClient({
+      ...apiCredentials,
+      endpoint: "content",
     });
   }
 
@@ -51,20 +51,14 @@ export class TSGhostContentAPI<Version extends `v5.${string}` = any> {
         identitySchema: slugOrIdSchema,
         include: authorsIncludeSchema,
       },
-      new HTTPClient({
-        ...this.credentials,
-        endpoint: "content",
-      }),
+      this.httpClient
     ).access(["read", "browse"]);
   }
   get tiers() {
     return new APIComposer(
       "tiers",
       { schema: tiersSchema, identitySchema: slugOrIdSchema, include: tiersIncludeSchema },
-      new HTTPClient({
-        ...this.credentials,
-        endpoint: "content",
-      }),
+      this.httpClient
     ).access(["browse", "read"]);
   }
   get posts() {
@@ -75,10 +69,7 @@ export class TSGhostContentAPI<Version extends `v5.${string}` = any> {
         identitySchema: slugOrIdSchema,
         include: postsIncludeSchema,
       },
-      new HTTPClient({
-        ...this.credentials,
-        endpoint: "content",
-      }),
+      this.httpClient
     ).access(["browse", "read"]);
   }
   get pages() {
@@ -89,31 +80,18 @@ export class TSGhostContentAPI<Version extends `v5.${string}` = any> {
         identitySchema: slugOrIdSchema,
         include: pagesIncludeSchema,
       },
-      new HTTPClient({
-        ...this.credentials,
-        endpoint: "content",
-      }),
+      this.httpClient
     ).access(["browse", "read"]);
   }
   get tags() {
     return new APIComposer(
       "tags",
       { schema: tagsSchema, identitySchema: slugOrIdSchema, include: tagsIncludeSchema },
-      new HTTPClient({
-        ...this.credentials,
-        endpoint: "content",
-      }),
+      this.httpClient
     ).access(["browse", "read"]);
   }
 
   get settings() {
-    return new BasicFetcher(
-      "settings",
-      { output: settingsSchema },
-      new HTTPClient({
-        ...this.credentials,
-        endpoint: "content",
-      }),
-    );
+    return new BasicFetcher("settings", { output: settingsSchema }, this.httpClient);
   }
 }

--- a/packages/ts-ghost-content-api/src/content-api.ts
+++ b/packages/ts-ghost-content-api/src/content-api.ts
@@ -2,7 +2,7 @@ import {
   APIComposer,
   BasicFetcher,
   contentAPICredentialsSchema,
-  HTTPClient,
+  HTTPClientFactory,
   slugOrIdSchema,
 } from "@ts-ghost/core-api";
 
@@ -25,19 +25,19 @@ export enum BrowseEndpointType {
 }
 
 export class TSGhostContentAPI<Version extends `v5.${string}` = any> {
-  private httpClient: HTTPClient;
+  private HTTPClientFactoryFactory: HTTPClientFactory;
 
   constructor(
     protected readonly url: string,
     protected readonly key: string,
-    protected readonly version: Version
+    protected readonly version: Version,
   ) {
     const apiCredentials = contentAPICredentialsSchema.parse({
       key,
       version,
       url,
     });
-    this.httpClient = new HTTPClient({
+    this.HTTPClientFactoryFactory = new HTTPClientFactory({
       ...apiCredentials,
       endpoint: "content",
     });
@@ -51,14 +51,14 @@ export class TSGhostContentAPI<Version extends `v5.${string}` = any> {
         identitySchema: slugOrIdSchema,
         include: authorsIncludeSchema,
       },
-      this.httpClient
+      this.HTTPClientFactoryFactory,
     ).access(["read", "browse"]);
   }
   get tiers() {
     return new APIComposer(
       "tiers",
       { schema: tiersSchema, identitySchema: slugOrIdSchema, include: tiersIncludeSchema },
-      this.httpClient
+      this.HTTPClientFactoryFactory,
     ).access(["browse", "read"]);
   }
   get posts() {
@@ -69,7 +69,7 @@ export class TSGhostContentAPI<Version extends `v5.${string}` = any> {
         identitySchema: slugOrIdSchema,
         include: postsIncludeSchema,
       },
-      this.httpClient
+      this.HTTPClientFactoryFactory,
     ).access(["browse", "read"]);
   }
   get pages() {
@@ -80,18 +80,18 @@ export class TSGhostContentAPI<Version extends `v5.${string}` = any> {
         identitySchema: slugOrIdSchema,
         include: pagesIncludeSchema,
       },
-      this.httpClient
+      this.HTTPClientFactoryFactory,
     ).access(["browse", "read"]);
   }
   get tags() {
     return new APIComposer(
       "tags",
       { schema: tagsSchema, identitySchema: slugOrIdSchema, include: tagsIncludeSchema },
-      this.httpClient
+      this.HTTPClientFactoryFactory,
     ).access(["browse", "read"]);
   }
 
   get settings() {
-    return new BasicFetcher("settings", { output: settingsSchema }, this.httpClient);
+    return new BasicFetcher("settings", { output: settingsSchema }, this.HTTPClientFactoryFactory.create());
   }
 }

--- a/packages/ts-ghost-core-api/src/api-composer.test.ts
+++ b/packages/ts-ghost-core-api/src/api-composer.test.ts
@@ -65,7 +65,7 @@ describe("APIComposer Read / Browse", () => {
     const composer = new APIComposer(
       "posts",
       { schema: simplifiedSchema, identitySchema: identitySchema, include: simplifiedIncludeSchema },
-      httpClientFactory,
+      new HTTPClientFactory(credentials),
     );
     test("pagination params", () => {
       expect(
@@ -102,7 +102,7 @@ describe("APIComposer Read / Browse", () => {
     const composer = new APIComposer(
       "posts",
       { schema: simplifiedSchema, identitySchema: identitySchema, include: simplifiedIncludeSchema },
-      httpClientFactory,
+      new HTTPClientFactory(credentials),
     );
     test("order params should accept a string with correct fields", () => {
       expect(
@@ -164,7 +164,7 @@ describe("APIComposer Read / Browse", () => {
     const composer = new APIComposer(
       "posts",
       { schema: simplifiedSchema, identitySchema: identitySchema, include: simplifiedIncludeSchema },
-      httpClientFactory,
+      new HTTPClientFactory(credentials),
     );
     test("filter params should accept a string with correct fields", () => {
       expect(
@@ -226,7 +226,7 @@ describe("APIComposer Read / Browse", () => {
     const composer = new APIComposer(
       "posts",
       { schema: simplifiedSchema, identitySchema: identitySchema, include: simplifiedIncludeSchema },
-      httpClientFactory,
+      new HTTPClientFactory(credentials),
     );
     test("identity read fields params should only accept key from the identity read schema", () => {
       expect(
@@ -256,7 +256,7 @@ describe("APIComposer Read / Browse", () => {
     const composer = new APIComposer(
       "posts",
       { schema: simplifiedSchema, identitySchema: identitySchema, include: simplifiedIncludeSchema },
-      httpClientFactory,
+      new HTTPClientFactory(credentials),
     );
     test("include params should only accept key from the include schema", () => {
       expect(composer.browse()).toBeInstanceOf(BrowseFetcher);

--- a/packages/ts-ghost-core-api/src/api-composer.test.ts
+++ b/packages/ts-ghost-core-api/src/api-composer.test.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { APIComposer } from "./api-composer";
 import { BrowseFetcher, ReadFetcher } from "./fetchers";
 import type { BrowseParams } from "./helpers/browse-params";
-import { HTTPClient, HTTPClientOptions } from "./helpers/http-client";
+import { HTTPClientFactory, HTTPClientOptions } from "./helpers/http-client";
 
 const fetchMocker = createFetchMock(vi);
 
@@ -16,7 +16,7 @@ describe("APIComposer Read / Browse", () => {
     version: "v5.0",
     endpoint: "content",
   };
-  let httpClient: HTTPClient;
+  let httpClientFactory: HTTPClientFactory;
 
   const simplifiedSchema = z.object({
     foo: z.string(),
@@ -37,7 +37,7 @@ describe("APIComposer Read / Browse", () => {
   ]);
 
   beforeEach(() => {
-    httpClient = new HTTPClient(credentials);
+    httpClientFactory = new HTTPClientFactory(credentials);
     fetchMocker.enableMocks();
   });
   afterEach(() => {
@@ -48,7 +48,7 @@ describe("APIComposer Read / Browse", () => {
     const composer = new APIComposer(
       "posts",
       { schema: simplifiedSchema, identitySchema: identitySchema, include: simplifiedIncludeSchema },
-      httpClient,
+      httpClientFactory,
     );
     expect(composer).toBeDefined();
     expect(composer.browse()).toBeInstanceOf(BrowseFetcher);
@@ -65,7 +65,7 @@ describe("APIComposer Read / Browse", () => {
     const composer = new APIComposer(
       "posts",
       { schema: simplifiedSchema, identitySchema: identitySchema, include: simplifiedIncludeSchema },
-      httpClient,
+      httpClientFactory,
     );
     test("pagination params", () => {
       expect(
@@ -102,7 +102,7 @@ describe("APIComposer Read / Browse", () => {
     const composer = new APIComposer(
       "posts",
       { schema: simplifiedSchema, identitySchema: identitySchema, include: simplifiedIncludeSchema },
-      httpClient,
+      httpClientFactory,
     );
     test("order params should accept a string with correct fields", () => {
       expect(
@@ -164,7 +164,7 @@ describe("APIComposer Read / Browse", () => {
     const composer = new APIComposer(
       "posts",
       { schema: simplifiedSchema, identitySchema: identitySchema, include: simplifiedIncludeSchema },
-      httpClient,
+      httpClientFactory,
     );
     test("filter params should accept a string with correct fields", () => {
       expect(
@@ -226,7 +226,7 @@ describe("APIComposer Read / Browse", () => {
     const composer = new APIComposer(
       "posts",
       { schema: simplifiedSchema, identitySchema: identitySchema, include: simplifiedIncludeSchema },
-      httpClient,
+      httpClientFactory,
     );
     test("identity read fields params should only accept key from the identity read schema", () => {
       expect(
@@ -256,7 +256,7 @@ describe("APIComposer Read / Browse", () => {
     const composer = new APIComposer(
       "posts",
       { schema: simplifiedSchema, identitySchema: identitySchema, include: simplifiedIncludeSchema },
-      httpClient,
+      httpClientFactory,
     );
     test("include params should only accept key from the include schema", () => {
       expect(composer.browse()).toBeInstanceOf(BrowseFetcher);
@@ -272,7 +272,7 @@ describe("APIComposer add / edit", () => {
     version: "v5.0",
     endpoint: "content",
   };
-  let httpClient: HTTPClient;
+  let httpClientFactory: HTTPClientFactory;
 
   const simplifiedSchema = z.object({
     id: z.string(),
@@ -300,7 +300,7 @@ describe("APIComposer add / edit", () => {
   });
 
   beforeEach(() => {
-    httpClient = new HTTPClient(credentials);
+    httpClientFactory = new HTTPClientFactory(credentials);
     fetchMocker.enableMocks();
     fetchMocker.enableMocks();
   });
@@ -326,7 +326,7 @@ describe("APIComposer add / edit", () => {
           update_option_1: z.boolean(),
         }),
       },
-      httpClient,
+      httpClientFactory,
     );
     expect(composer).toBeDefined();
     expect(composer.browse()).toBeInstanceOf(BrowseFetcher);
@@ -367,7 +367,7 @@ describe("APIComposer add / edit", () => {
         //   foobar: z.string(),
         // }),
       },
-      httpClient,
+      httpClientFactory,
     );
     fetchMocker.doMockOnce(
       JSON.stringify({
@@ -433,7 +433,7 @@ describe("APIComposer add / edit", () => {
         //   foobar: z.string(),
         // }),
       },
-      httpClient,
+      httpClientFactory,
     );
     const mockData = {
       id: "abc",
@@ -480,7 +480,7 @@ describe("APIComposer add / edit", () => {
         //   foobar: z.string(),
         // }),
       },
-      httpClient,
+      httpClientFactory,
     );
     fetchMocker.doMockOnce(
       JSON.stringify({
@@ -540,7 +540,7 @@ describe("APIComposer add / edit", () => {
         //   foobar: z.string(),
         // }),
       },
-      httpClient,
+      httpClientFactory,
     );
     fetchMocker.doMockOnce(
       JSON.stringify({
@@ -595,7 +595,7 @@ describe("APIComposer add / edit", () => {
           newsletter: z.string().optional(),
         }),
       },
-      httpClient,
+      httpClientFactory,
     );
     fetchMocker.doMockOnce(
       JSON.stringify({
@@ -650,7 +650,7 @@ describe("APIComposer add / edit", () => {
         //   foobar: z.string(),
         // }),
       },
-      httpClient,
+      httpClientFactory,
     );
     fetchMocker.doMockOnce(
       JSON.stringify({

--- a/packages/ts-ghost-core-api/src/api-composer.ts
+++ b/packages/ts-ghost-core-api/src/api-composer.ts
@@ -5,7 +5,7 @@ import { BrowseFetcher } from "./fetchers/browse-fetcher";
 import { MutationFetcher } from "./fetchers/mutation-fetcher";
 import { ReadFetcher } from "./fetchers/read-fetcher";
 import { parseBrowseParams, type BrowseParams } from "./helpers/browse-params";
-import type { HTTPClient } from "./helpers/http-client";
+import type { HTTPClientFactory } from "./helpers/http-client";
 import type { APIResource } from "./schemas";
 import type { IsAny } from "./utils";
 
@@ -37,7 +37,7 @@ export class APIComposer<
       updateSchema?: UpdateShape;
       updateOptionsSchema?: UpdateOptions;
     },
-    protected httpClient: HTTPClient,
+    protected httpClientFactory: HTTPClientFactory,
   ) {}
 
   /**
@@ -65,7 +65,7 @@ export class APIComposer<
         browseParams:
           (options && parseBrowseParams(options, this.config.schema, this.config.include)) || undefined,
       },
-      this.httpClient,
+      this.httpClientFactory.create(),
     );
   }
 
@@ -84,7 +84,7 @@ export class APIComposer<
       {
         identity: this.config.identitySchema.parse(options),
       },
-      this.httpClient,
+      this.httpClientFactory.create(),
     );
   }
 
@@ -105,7 +105,7 @@ export class APIComposer<
       },
       parsedOptions,
       { method: "POST", body: parsedData },
-      this.httpClient,
+      this.httpClientFactory.create(),
     );
     return fetcher.submit();
   }
@@ -138,14 +138,14 @@ export class APIComposer<
       },
       { id: cleanId, ...parsedOptions },
       { method: "PUT", body: parsedData },
-      this.httpClient,
+      this.httpClientFactory.create(),
     );
     return fetcher.submit();
   }
 
   public async delete(id: string) {
     const cleanId = z.string().nonempty().parse(id);
-    const fetcher = new DeleteFetcher(this.resource, { id: cleanId }, this.httpClient);
+    const fetcher = new DeleteFetcher(this.resource, { id: cleanId }, this.httpClientFactory.create());
     return fetcher.submit();
   }
 

--- a/packages/ts-ghost-core-api/src/fetchers/basic-fetcher.test.ts
+++ b/packages/ts-ghost-core-api/src/fetchers/basic-fetcher.test.ts
@@ -36,7 +36,7 @@ describe("BasicFetcher", () => {
           foo: "foo",
           bar: "eaoizdjoa1321123",
         },
-      })
+      }),
     );
     const result = await fetcher.fetch();
 
@@ -69,7 +69,7 @@ describe("BasicFetcher", () => {
             message: "error message",
           },
         ],
-      })
+      }),
     );
 
     const result = await fetcher.fetch();

--- a/packages/ts-ghost-core-api/src/fetchers/basic-fetcher.ts
+++ b/packages/ts-ghost-core-api/src/fetchers/basic-fetcher.ts
@@ -9,7 +9,7 @@ export class BasicFetcher<const Resource extends APIResource = any, OutputShape 
     protected config: {
       output: OutputShape;
     },
-    protected httpClient: HTTPClient
+    protected httpClient: HTTPClient,
   ) {}
 
   public getResource() {
@@ -28,7 +28,7 @@ export class BasicFetcher<const Resource extends APIResource = any, OutputShape 
           z.object({
             type: z.string(),
             message: z.string(),
-          })
+          }),
         ),
       }),
     ]);

--- a/packages/ts-ghost-core-api/src/helpers/http-client.ts
+++ b/packages/ts-ghost-core-api/src/helpers/http-client.ts
@@ -38,6 +38,18 @@ export interface IHTTPClient {
   }): Promise<Response>;
 }
 
+export interface IHTTPClientFactory {
+  create(config: HTTPClientOptions): HTTPClient;
+}
+
+export class HTTPClientFactory implements IHTTPClientFactory {
+  constructor(private config: HTTPClientOptions) {}
+
+  public create() {
+    return new HTTPClient(this.config);
+  }
+}
+
 export class HTTPClient<const Options extends HTTPClientOptions = any> implements IHTTPClient {
   private _jwt: string | undefined;
   private _jwtExpiresAt: number | undefined;
@@ -69,7 +81,7 @@ export class HTTPClient<const Options extends HTTPClientOptions = any> implement
       .setIssuedAt()
       .setAudience("/admin/")
       .sign(
-        Uint8Array.from((_secret.match(/.{1,2}/g) as RegExpMatchArray).map((byte) => parseInt(byte, 16)))
+        Uint8Array.from((_secret.match(/.{1,2}/g) as RegExpMatchArray).map((byte) => parseInt(byte, 16))),
       );
   }
 


### PR DESCRIPTION
Closes #213 

One of the goal of the lib was, "bring your own fetcher" (fetch, axios, etc). So the API Composer was using a HTTPClient instanced at a high level in the class composition chain. 

This was a bad decision since the HTTP Client class was itself an instance and not a Factory or anything reusable so the params can collide creating broken URL on that reused instance.

## Changes

- To keep the idea of "bringing your own fetcher" if you wanted to pull the create your own version of the API there is now a new HTTPClientFactory. This will instantiate a factory with the correct credentials, this factory will take care of creating new instances of HTTPClient.

## Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/PhilDL/ts-ghost/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
