### PR TITLE
fix ghost url with custom port

### DIFF
--- a/.changeset/tasty-baboons-battle.md
+++ b/.changeset/tasty-baboons-battle.md
@@ -1,0 +1,5 @@
+---
+"@ts-ghost/ghost-blog-buster": patch
+---
+
+fix connection to ghost instances deployed on custom ports

--- a/apps/ghost-blog-buster/src/commands/interactive-admin-api/prompt-credentials-loop.ts
+++ b/apps/ghost-blog-buster/src/commands/interactive-admin-api/prompt-credentials-loop.ts
@@ -46,7 +46,7 @@ export const promptCredentialsLoop = async (config: Configstore) => {
       process.exit(0);
     }
     try {
-      const ghost = new TSGhostAdminAPI(`${url.protocol}//${url.hostname}`, ghostAdminApiKey, "v5.0");
+      const ghost = new TSGhostAdminAPI(`${url.protocol}//${url.hostname}${url.port ? `:${url.port}` : ''}`, ghostAdminApiKey, "v5.0");
       s.start("Validating credentials");
       const res = await ghost.site.fetch();
       if (res.success) {

--- a/apps/ghost-blog-buster/src/commands/interactive-admin-api/prompt-credentials-loop.ts
+++ b/apps/ghost-blog-buster/src/commands/interactive-admin-api/prompt-credentials-loop.ts
@@ -30,7 +30,7 @@ export const promptCredentialsLoop = async (config: Configstore) => {
       process.exit(0);
     }
     const url = new URL(ghostUrl);
-    lastUrlInput = `${url.protocol}//${url.hostname}`;
+    lastUrlInput = url.origin;
     const ghostAdminApiKey = await text({
       message: `Enter a Ghost Admin API key. Here you can use a Staff Access token (RECOMMENDED: found on a User) or create a new Integration at ${url.protocol}//${url.hostname}/ghost/#/settings/integrations and copy the Admin API Key`,
       placeholder:
@@ -46,12 +46,12 @@ export const promptCredentialsLoop = async (config: Configstore) => {
       process.exit(0);
     }
     try {
-      const ghost = new TSGhostAdminAPI(`${url.protocol}//${url.hostname}${url.port ? `:${url.port}` : ''}`, ghostAdminApiKey, "v5.0");
+      const ghost = new TSGhostAdminAPI(url.origin, ghostAdminApiKey, "v5.0");
       s.start("Validating credentials");
       const res = await ghost.site.fetch();
       if (res.success) {
         const settings = res.data;
-        config.set("ghostUrl", `${url.protocol}//${url.hostname}`);
+        config.set("ghostUrl", url.origin);
         config.set("ghostAdminApiKey", ghostAdminApiKey);
         config.set("siteName", settings.title);
         s.stop(`✅ Connected to ${settings.title}`);

--- a/apps/ghost-blog-buster/src/commands/interactive-content-api/prompt-credentials-loop.ts
+++ b/apps/ghost-blog-buster/src/commands/interactive-content-api/prompt-credentials-loop.ts
@@ -30,7 +30,7 @@ export const promptCredentialsLoop = async (config: Configstore) => {
       process.exit(0);
     }
     const url = new URL(ghostUrl);
-    lastUrlInput = `${url.protocol}//${url.hostname}`;
+    lastUrlInput = url.origin;
     const ghostContentApiKey = await text({
       message: `Enter your Ghost Content API key or create a new Integration at ${url.protocol}//${url.hostname}/ghost/#/settings/integrations`,
       placeholder: "eb3144f144F41d43c737350dc3",
@@ -44,12 +44,12 @@ export const promptCredentialsLoop = async (config: Configstore) => {
       process.exit(0);
     }
     try {
-      const ghost = new TSGhostContentAPI(`${url.protocol}//${url.hostname}${url.port ? `:${url.port}` : ''}`, ghostContentApiKey, "v5.0");
+      const ghost = new TSGhostContentAPI(url.origin, ghostContentApiKey, "v5.0");
       s.start("Validating credentials");
       const res = await ghost.settings.fetch();
       if (res.success) {
         const settings = res.data;
-        config.set("ghostUrl", `${url.protocol}//${url.hostname}`);
+        config.set("ghostUrl", url.origin);
         config.set("ghostContentApiKey", ghostContentApiKey);
         config.set("siteName", settings.title);
         s.stop(`✅ Connected to ${settings.title}`);

--- a/apps/ghost-blog-buster/src/commands/interactive-content-api/prompt-credentials-loop.ts
+++ b/apps/ghost-blog-buster/src/commands/interactive-content-api/prompt-credentials-loop.ts
@@ -44,7 +44,7 @@ export const promptCredentialsLoop = async (config: Configstore) => {
       process.exit(0);
     }
     try {
-      const ghost = new TSGhostContentAPI(`${url.protocol}//${url.hostname}`, ghostContentApiKey, "v5.0");
+      const ghost = new TSGhostContentAPI(`${url.protocol}//${url.hostname}${url.port ? `:${url.port}` : ''}`, ghostContentApiKey, "v5.0");
       s.start("Validating credentials");
       const res = await ghost.settings.fetch();
       if (res.success) {


### PR DESCRIPTION
Closes #229 

## Changes

This fix the Ghost URL crafting logic appending the port when necessary.
I wonder if you'd accept to just use `url.origin` instead of going over the URL properties and picking them one by one.

## Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/PhilDL/ts-ghost/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.


## Testing

I couldn't find anything that is ultimately testing the blog-buster package. Just ask to add if needed