### PR TITLE
236 bug postauthors has slightly different type than author

### DIFF
--- a/.changeset/slimy-lions-drum.md
+++ b/.changeset/slimy-lions-drum.md
@@ -1,7 +1,14 @@
 ---
+"@ts-ghost/admin-api": minor
 "@ts-ghost/content-api": minor
 "@ts-ghost/core-api": minor
 ---
+
+## Global
+
+- Upgrade Zod version and fix types, no breaking changes were introduced.
+
+## `@ts-ghost/content-api`
 
 Change type of `url` on `Author` for the content API to align with the `post.authors` and `page.authors` type.
 An author can have an undefined or null `url` if the author is not set as visible.

--- a/.changeset/slimy-lions-drum.md
+++ b/.changeset/slimy-lions-drum.md
@@ -1,0 +1,10 @@
+---
+"@ts-ghost/content-api": minor
+"@ts-ghost/core-api": minor
+---
+
+Change type of `url` on `Author` for the content API to align with the `post.authors` and `page.authors` type.
+An author can have an undefined or null `url` if the author is not set as visible.
+
+- New type is now `string | undefined | null` instead of `string`.
+- Updated the `Author` type in the `content-api` package to reflect this change.

--- a/packages/ts-ghost-content-api/src/authors/schemas.ts
+++ b/packages/ts-ghost-content-api/src/authors/schemas.ts
@@ -17,7 +17,7 @@ export const authorsSchema = z.object({
       posts: z.number(),
     })
     .optional(),
-  url: z.string(),
+  url: z.string().nullish(),
 });
 
 export type Author = z.infer<typeof authorsSchema>;

--- a/packages/ts-ghost-content-api/vitest.config.ts
+++ b/packages/ts-ghost-content-api/vitest.config.ts
@@ -11,5 +11,8 @@ export default defineConfig({
     include: ["./**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
     watchExclude: [".*\\/node_modules\\/.*", ".*\\/build\\/.*"],
     exclude: ["node_modules", "dist", ".idea", ".git", ".cache", "**/*integration.test.ts"],
+    typecheck: {
+      include: ["./**/*.{ts,tsx}"],
+    },
   },
 });

--- a/packages/ts-ghost-core-api/src/schemas/authors.ts
+++ b/packages/ts-ghost-core-api/src/schemas/authors.ts
@@ -18,5 +18,5 @@ export const baseAuthorsSchema = z.object({
       posts: z.number(),
     })
     .optional(),
-  url: z.string(),
+  url: z.string().nullish(),
 });


### PR DESCRIPTION
Closes #236 

## Changes

Change type of `url` on `Author` for the content API to align with the `post.authors` and `page.authors` type.
An author can have an undefined or null `url` if the author is not set as visible.

- New type is now `string | undefined | null` instead of `string`.
- Updated the `Author` type in the `content-api` package to reflect this change.

## Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/PhilDL/ts-ghost/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
