### PR TITLE
fix(admin-api): lexical output for pages

### DIFF
--- a/.changeset/thin-wolves-join.md
+++ b/.changeset/thin-wolves-join.md
@@ -1,0 +1,5 @@
+---
+"@ts-ghost/admin-api": patch
+---
+
+fix(admin-api): lexical output for pages

--- a/packages/ts-ghost-admin-api/src/schemas/pages.ts
+++ b/packages/ts-ghost-admin-api/src/schemas/pages.ts
@@ -22,6 +22,12 @@ export const adminPagesSchema = basePagesSchema.merge(
       .nullish(),
     authors: z.array(adminAuthorsSchema),
     primary_author: adminAuthorsSchema,
+    lexical: z
+      .string()
+      .catch(
+        '{"root":{"children":[{"children":[],"direction":null,"format":"","indent":0,"type":"paragraph","version":1}],"direction":null,"format":"","indent":0,"type":"root","version":1}}',
+      )
+      .optional(),
     html: z.string().catch("").optional(),
     plaintext: z.string().catch("").optional(),
   })


### PR DESCRIPTION
Closes `no issue created`

## Changes

Fixes the Admin API package's failure to return Lexical output for pages when requested.

## Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/PhilDL/ts-ghost/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
